### PR TITLE
Asset compiler changes

### DIFF
--- a/Source/AssetCompiler/Handlers/BaseCompiler.cs
+++ b/Source/AssetCompiler/Handlers/BaseCompiler.cs
@@ -2,5 +2,46 @@
 
 public abstract class BaseCompiler
 {
-	public abstract string CompileFile( string path );
+	/// <summary>
+	/// The name of the asset this compiler works with.
+	/// </summary>
+	public abstract string AssetName { get; }
+
+	/// <summary>
+	/// Compiles the asset.
+	/// </summary>
+	/// <param name="path">The path to the source asset.</param>
+	/// <returns>The result of the compilation.</returns>
+	public abstract CompileResult CompileFile( string path );
+
+	protected static CompileResult UpToDate( string sourcePath, string destinationPath )
+	{
+		return new CompileResult()
+		{
+			State = CompileState.UpToDate,
+			SourcePath = sourcePath,
+			DestinationPath = destinationPath,
+			Error = null
+		};
+	}
+	protected static CompileResult Succeeded( string sourcePath, string destinationPath )
+	{
+		return new CompileResult()
+		{
+			State = CompileState.Succeeded,
+			SourcePath = sourcePath,
+			DestinationPath = destinationPath,
+			Error = null
+		};
+	}
+	protected static CompileResult Failed( string sourcePath, string? destinationPath = null, Exception? exception = null )
+	{
+		return new CompileResult()
+		{
+			State = CompileState.Failed,
+			SourcePath = sourcePath,
+			DestinationPath = destinationPath,
+			Error = exception
+		};
+	}
 }

--- a/Source/AssetCompiler/Handlers/CompileResult.cs
+++ b/Source/AssetCompiler/Handlers/CompileResult.cs
@@ -1,0 +1,26 @@
+﻿namespace Mocha.AssetCompiler;
+
+/// <summary>
+/// Represents a result from an asset compilation.
+/// </summary>
+public readonly struct CompileResult
+{
+	/// <summary>
+	/// The resulting state of the compilation.
+	/// </summary>
+	public CompileState State { get; init; }
+
+	/// <summary>
+	/// The source path of the asset.
+	/// </summary>
+	public string SourcePath { get; init; }
+	/// <summary>
+	/// The destination path of the compiled asset.
+	/// </summary>
+	public string? DestinationPath { get; init; }
+
+	/// <summary>
+	/// An exception that represents the reason for the compile to fail.
+	/// </summary>
+	public Exception? Error { get; init; }
+}

--- a/Source/AssetCompiler/Handlers/CompileState.cs
+++ b/Source/AssetCompiler/Handlers/CompileState.cs
@@ -1,0 +1,11 @@
+﻿namespace Mocha.AssetCompiler;
+
+/// <summary>
+/// Represents an ending state of an assets compilation.
+/// </summary>
+public enum CompileState
+{
+	UpToDate,
+	Succeeded,
+	Failed
+}

--- a/Source/AssetCompiler/Handlers/Font/FontCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Font/FontCompiler.cs
@@ -9,10 +9,10 @@ namespace Mocha.AssetCompiler;
 [Handles( new[] { ".ttf" } )]
 public class FontCompiler : BaseCompiler
 {
-	public override string CompileFile( string path )
-	{
-		Log.Processing( "Font", path );
+	public override string AssetName => "Font";
 
+	public override CompileResult CompileFile( string path )
+	{
 		var destJsonFileName = Path.ChangeExtension( path, ".temp.json" );
 		var destAtlasFileName = Path.ChangeExtension( path, ".png" );
 		var destFileName = Path.ChangeExtension( path, "mfnt_c" );
@@ -25,10 +25,7 @@ public class FontCompiler : BaseCompiler
 			var deserializedFile = Serializer.Deserialize<MochaFile<Font.Data>>( existingFile );
 
 			if ( deserializedFile.Data.ModifiedDate == File.GetLastWriteTime( path ).ToString() )
-			{
-				Log.Skip( path );
-				return destFileName;
-			}
+				return UpToDate( path, destFileName );
 		}
 
 		var charSetFileName = Path.ChangeExtension( path, ".txt" );
@@ -105,6 +102,6 @@ public class FontCompiler : BaseCompiler
 
 		// Delete original atlas file
 		File.Delete( destAtlasFileName );
-		return destJsonFileName;
+		return Succeeded( path, destJsonFileName );
 	}
 }

--- a/Source/AssetCompiler/Handlers/Material/MaterialCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Material/MaterialCompiler.cs
@@ -8,10 +8,10 @@ namespace Mocha.AssetCompiler;
 [Handles( new[] { ".mmat" } )]
 public class MaterialCompiler : BaseCompiler
 {
-	public override string CompileFile( string path )
-	{
-		Log.Processing( "Material", path );
+	public override string AssetName => "Material";
 
+	public override CompileResult CompileFile( string path )
+	{
 		var destFileName = Path.ChangeExtension( path, "mmat_c" );
 
 		// Load json
@@ -35,6 +35,6 @@ public class MaterialCompiler : BaseCompiler
 		using var binaryWriter = new BinaryWriter( fileStream );
 
 		binaryWriter.Write( Serializer.Serialize( mochaFile ) );
-		return destFileName;
+		return Succeeded( path, destFileName );
 	}
 }

--- a/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
@@ -5,10 +5,10 @@ namespace Mocha.AssetCompiler;
 [Handles( new[] { ".mmdl" } )]
 public class ModelCompiler : BaseCompiler
 {
-	public override string CompileFile( string path )
-	{
-		Log.Processing( "Model", path );
+	public override string AssetName => "Model";
 
+	public override CompileResult CompileFile( string path )
+	{
 		var destFileName = Path.ChangeExtension( path, "mmdl_c" );
 
 		using var fileStream = new FileStream( destFileName, FileMode.Create );
@@ -88,6 +88,6 @@ public class ModelCompiler : BaseCompiler
 			}
 		}
 
-		return destFileName;
+		return Succeeded( path, destFileName );
 	}
 }

--- a/Source/AssetCompiler/Handlers/Texture/TextureCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Texture/TextureCompiler.cs
@@ -9,6 +9,8 @@ namespace Mocha.AssetCompiler;
 [Handles( new[] { ".png", ".jpg" } )]
 public class TextureCompiler : BaseCompiler
 {
+	public override string AssetName => "Texture";
+
 	private static byte[] BlockCompression( byte[] data, int width, int height, int mip, CompressionFormat compressionFormat )
 	{
 		BcEncoder encoder = new BcEncoder();
@@ -21,10 +23,8 @@ public class TextureCompiler : BaseCompiler
 		return encoder.EncodeToRawBytes( data, width, height, PixelFormat.Rgba32, mip, out _, out _ );
 	}
 
-	public override string CompileFile( string path )
+	public override CompileResult CompileFile( string path )
 	{
-		Log.Processing( "Texture", path );
-
 		var destFileName = Path.ChangeExtension( path, "mtex_c" );
 		var textureFormat = new TextureInfo();
 
@@ -42,11 +42,7 @@ public class TextureCompiler : BaseCompiler
 			using var md5 = MD5.Create();
 			var computedHash = md5.ComputeHash( fileData );
 			if ( Enumerable.SequenceEqual( deserializedFile.AssetHash, computedHash ) )
-			{
-				Log.Skip( path );
-
-				return destFileName;
-			}
+				return UpToDate( path, destFileName );
 		}
 
 		textureFormat.Width = (uint)image.Width;
@@ -100,6 +96,6 @@ public class TextureCompiler : BaseCompiler
 		using var binaryWriter = new BinaryWriter( fileStream );
 
 		binaryWriter.Write( Serializer.Serialize( mochaFile ) );
-		return destFileName;
+		return Succeeded( path, destFileName );
 	}
 }

--- a/Source/AssetCompiler/Logger.cs
+++ b/Source/AssetCompiler/Logger.cs
@@ -8,7 +8,8 @@ public class Logger
 	private int UpToDateCount = 0;
 
 	private void Log( string prefix, string message ) => Console.WriteLine( $"{"[" + prefix.ToUpper() + "]",-16}{message}" );
-	public void Skip( string path )
+
+	public void UpToDate( string path )
 	{
 		UpToDateCount++;
 		Log( "Up-to-date", $"Not compiling '{path}' as it matches compiled version" );

--- a/Source/AssetCompiler/Logger.cs
+++ b/Source/AssetCompiler/Logger.cs
@@ -26,6 +26,12 @@ public class Logger
 		Log( "Success", $"Compiled '{path}'" );
 	}
 
+	public void Fail( string path, Exception? e = null )
+	{
+		FailCount++;
+		Log( "Fail", $"{path} failed to compile. Error was: {e?.Message ?? "Unknown"}" );
+	}
+
 	public void Processing( string type, string path ) => Log( "PROCESS", $"Processing '{path}' as {type}" );
 
 	public void Results( TimeSpan totalTime ) => Log( "Results", $"========== Build: {SuccessCount} succeeded, {FailCount} failed, {UpToDateCount} up-to-date, {SkipCount} skipped ==========\nBuild took {totalTime.TotalSeconds} seconds." );

--- a/Source/AssetCompiler/Program.cs
+++ b/Source/AssetCompiler/Program.cs
@@ -1,4 +1,5 @@
 ﻿global using Mocha.Common;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace Mocha.AssetCompiler;
@@ -107,14 +108,24 @@ public static class Program
 
 		// TODO: Check if we have an original asset & if it needs recompiling
 
-		if ( GetCompiler( fileExtension, out var compiler ) )
+		if ( !GetCompiler( fileExtension, out var compiler ) )
+			return;
+
+		Log.Processing( compiler.AssetName, path );
+		var result = compiler.CompileFile( path );
+
+		switch ( result.State )
 		{
-			var destFile = compiler?.CompileFile( path );
-
-			if ( destFile == null )
+			case CompileState.UpToDate:
+				Log.UpToDate( result.DestinationPath! );
+				break;
+			case CompileState.Succeeded:
+				Log.Compiled( result.DestinationPath! );
+				break;
+			case CompileState.Failed:
 				throw new Exception( "Failed to compile?" );
-
-			Log.Compiled( destFile );
+			default:
+				throw new UnreachableException();
 		}
 	}
 }

--- a/Source/AssetCompiler/Program.cs
+++ b/Source/AssetCompiler/Program.cs
@@ -47,7 +47,14 @@ public static class Program
 		{
 			foreach ( var item in threadQueue )
 			{
-				CompileFile( item );
+				try
+				{
+					CompileFile( item );
+				}
+				catch( Exception e )
+				{
+					Log.Fail( item, e );
+				}
 			}
 		}, queue );
 

--- a/Source/AssetCompiler/Program.cs
+++ b/Source/AssetCompiler/Program.cs
@@ -1,5 +1,6 @@
 ﻿global using Mocha.Common;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Mocha.AssetCompiler;
@@ -42,16 +43,12 @@ public static class Program
 			CompileFile( path );
 		}
 
-		var completedThreads = 0;
-
 		var dispatcher = new ThreadDispatcher<string>( ( threadQueue ) =>
 		{
 			foreach ( var item in threadQueue )
 			{
 				CompileFile( item );
 			}
-
-			completedThreads++;
 		}, queue );
 
 		while ( !dispatcher.IsComplete )
@@ -73,7 +70,7 @@ public static class Program
 		}
 	}
 
-	private static bool GetCompiler( string fileExtension, out BaseCompiler? foundCompiler )
+	private static bool GetCompiler( string fileExtension, [NotNullWhen( true )] out BaseCompiler? foundCompiler )
 	{
 		foreach ( var compiler in Compilers )
 		{


### PR DESCRIPTION
Changed compilers to return a `CompileResult` instead of a string. This PR also removes logging from the compilers so that they can be used outside of the command line project; Like runtime compilation for example.