### PR TITLE
Fix release build

### DIFF
--- a/Source/Host/rendermanager.h
+++ b/Source/Host/rendermanager.h
@@ -35,14 +35,14 @@ public:
 
 	const char* GetGPUName()
 	{
-		GPUInfo info;
+		GPUInfo info{};
 		assert( m_renderContext->GetGPUInfo( &info ) == RENDER_STATUS_OK );
 		return info.gpuName;
 	}
 
 	Size2D GetWindowExtent()
 	{
-		Size2D size;
+		Size2D size{};
 		assert( m_renderContext->GetRenderSize( &size ) == RENDER_STATUS_OK );
 		return size;
 	}


### PR DESCRIPTION
Currently, the release build of Mocha fails because uninitialized memory is used. This PR fixes that by just doing a simple initialization on the offending structs.