### PR TITLE
Asset compiler improvements

### DIFF
--- a/Source/AssetCompiler/AssetCompilerBase.cs
+++ b/Source/AssetCompiler/AssetCompilerBase.cs
@@ -120,7 +120,7 @@ public class AssetCompilerBase : IAssetCompiler
 		CompileResult result;
 		try
 		{
-			result = compiler.CompileFile( ref input );
+			result = compiler.Compile( ref input );
 		}
 		catch( Exception e )
 		{

--- a/Source/AssetCompiler/AssetCompilerBase.cs
+++ b/Source/AssetCompiler/AssetCompilerBase.cs
@@ -8,6 +8,9 @@ namespace Mocha.AssetCompiler;
 
 public class AssetCompilerBase : IAssetCompiler
 {
+	/// <summary>
+	/// A list containing all found compilers.
+	/// </summary>
 	protected List<BaseCompiler> Compilers = new();
 
 	private readonly Dictionary<string, BaseCompiler> ExtensionToCompilerCache = new();

--- a/Source/AssetCompiler/Handlers/BaseCompiler.cs
+++ b/Source/AssetCompiler/Handlers/BaseCompiler.cs
@@ -8,40 +8,55 @@ public abstract class BaseCompiler
 	public abstract string AssetName { get; }
 
 	/// <summary>
+	/// The file extension attributed to the asset this compiler works with.
+	/// </summary>
+	public abstract string CompiledExtension { get; }
+
+	/// <summary>
+	/// Whether or not the asset uses <see cref="MochaFile{T}"/> for its (de)serialization.
+	/// </summary>
+	public abstract bool SupportsMochaFile { get; }
+
+	/// <summary>
+	/// An array of file patterns that can be associated with the assets compilation.
+	/// </summary>
+	public virtual string[] AssociatedFiles => Array.Empty<string>();
+
+	/// <summary>
 	/// Compiles the asset.
 	/// </summary>
-	/// <param name="path">The path to the source asset.</param>
+	/// <param name="input"></param>
 	/// <returns>The result of the compilation.</returns>
-	public abstract CompileResult CompileFile( string path );
+	public abstract CompileResult CompileFile( ref CompileInput input );
 
-	protected static CompileResult UpToDate( string sourcePath, string destinationPath )
-	{
-		return new CompileResult()
-		{
-			State = CompileState.UpToDate,
-			SourcePath = sourcePath,
-			DestinationPath = destinationPath,
-			Error = null
-		};
-	}
-	protected static CompileResult Succeeded( string sourcePath, string destinationPath )
+	/// <summary>
+	/// Returns a <see cref="CompileState.Succeeded"/> result with the provided data.
+	/// </summary>
+	/// <param name="data">The compiled data.</param>
+	/// <param name="associatedData">The compiled version of any associated data.</param>
+	/// <returns>The created result of the compilation.</returns>
+	protected static CompileResult Succeeded( ReadOnlyMemory<byte> data, IReadOnlyDictionary<string, ReadOnlyMemory<byte>>? associatedData = null )
 	{
 		return new CompileResult()
 		{
 			State = CompileState.Succeeded,
-			SourcePath = sourcePath,
-			DestinationPath = destinationPath,
-			Error = null
+			Exception = null,
+			Data = data,
+			AssociatedData = associatedData ?? new Dictionary<string, ReadOnlyMemory<byte>>( 0 )
 		};
 	}
-	protected static CompileResult Failed( string sourcePath, string? destinationPath = null, Exception? exception = null )
+
+	/// <summary>
+	/// Returns a <see cref="CompileState.Failed"/> result with the provided <see cref="Exception"/>.
+	/// </summary>
+	/// <param name="exception">The exception that occurred during the compilation.</param>
+	/// <returns>The created result of the compilation.</returns>
+	protected static CompileResult Failed( Exception? exception = null )
 	{
 		return new CompileResult()
 		{
 			State = CompileState.Failed,
-			SourcePath = sourcePath,
-			DestinationPath = destinationPath,
-			Error = exception
+			Exception = exception
 		};
 	}
 }

--- a/Source/AssetCompiler/Handlers/BaseCompiler.cs
+++ b/Source/AssetCompiler/Handlers/BaseCompiler.cs
@@ -27,7 +27,7 @@ public abstract class BaseCompiler
 	/// </summary>
 	/// <param name="input"></param>
 	/// <returns>The result of the compilation.</returns>
-	public abstract CompileResult CompileFile( ref CompileInput input );
+	public abstract CompileResult Compile( ref CompileInput input );
 
 	/// <summary>
 	/// Returns a <see cref="CompileState.Succeeded"/> result with the provided data.

--- a/Source/AssetCompiler/Handlers/CompileInput.cs
+++ b/Source/AssetCompiler/Handlers/CompileInput.cs
@@ -1,0 +1,27 @@
+﻿namespace Mocha.AssetCompiler;
+
+/// <summary>
+/// Represents an input to a asset compiler.
+/// </summary>
+public readonly struct CompileInput
+{
+	/// <summary>
+	/// The absolute path to the asset the <see ref="Data"/> came from. Null if in memory.
+	/// </summary>
+	public string? SourcePath { get; init; }
+
+	/// <summary>
+	/// The main data portion for the asset.
+	/// </summary>
+	public ReadOnlyMemory<byte> SourceData { get; init; }
+
+	/// <summary>
+	/// Contains any extra data to be compiled alongside the <see ref="SourceData"/>.
+	/// </summary>
+	public IReadOnlyDictionary<string, ReadOnlyMemory<byte>> AssociatedData { get; init; }
+
+	/// <summary>
+	/// The <see cref="System.Security.Cryptography.MD5"/> hash of all data files.
+	/// </summary>
+	public byte[] DataHash { get; init; }
+}

--- a/Source/AssetCompiler/Handlers/CompileResult.cs
+++ b/Source/AssetCompiler/Handlers/CompileResult.cs
@@ -11,16 +11,17 @@ public readonly struct CompileResult
 	public CompileState State { get; init; }
 
 	/// <summary>
-	/// The source path of the asset.
-	/// </summary>
-	public string SourcePath { get; init; }
-	/// <summary>
-	/// The destination path of the compiled asset.
-	/// </summary>
-	public string? DestinationPath { get; init; }
-
-	/// <summary>
 	/// An exception that represents the reason for the compile to fail.
 	/// </summary>
-	public Exception? Error { get; init; }
+	public Exception? Exception { get; init; }
+
+	/// <summary>
+	/// The resulting data from the compilation.
+	/// </summary>
+	public ReadOnlyMemory<byte> Data { get; init; }
+
+	/// <summary>
+	/// The resulting data of any other associated portions of the compilation.
+	/// </summary>
+	public IReadOnlyDictionary<string, ReadOnlyMemory<byte>> AssociatedData { get; init; }
 }

--- a/Source/AssetCompiler/Handlers/CompileState.cs
+++ b/Source/AssetCompiler/Handlers/CompileState.cs
@@ -5,7 +5,6 @@
 /// </summary>
 public enum CompileState
 {
-	UpToDate,
 	Succeeded,
 	Failed
 }

--- a/Source/AssetCompiler/Handlers/Font/FontCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Font/FontCompiler.cs
@@ -27,7 +27,7 @@ public class FontCompiler : BaseCompiler
 	};
 
 	/// <inheritdoc/>
-	public override CompileResult CompileFile( ref CompileInput input )
+	public override CompileResult Compile( ref CompileInput input )
 	{
 		// TODO: Fix this
 		if ( input.SourcePath is null )

--- a/Source/AssetCompiler/Handlers/Font/FontCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Font/FontCompiler.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 
 namespace Mocha.AssetCompiler;
 
-[Handles( new[] { ".ttf" } )]
+[Handles( ".ttf" )]
 public class FontCompiler : BaseCompiler
 {
 	public override string AssetName => "Font";

--- a/Source/AssetCompiler/Handlers/HandlesAttribute.cs
+++ b/Source/AssetCompiler/Handlers/HandlesAttribute.cs
@@ -3,9 +3,9 @@
 [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = false )]
 public class HandlesAttribute : Attribute
 {
-	public string[] Extensions;
-
-	public HandlesAttribute( string[] extensions )
+	public string[] Extensions { get; }
+	
+	public HandlesAttribute( params string[] extensions )
 	{
 		Extensions = extensions;
 	}

--- a/Source/AssetCompiler/Handlers/HandlesAttribute.cs
+++ b/Source/AssetCompiler/Handlers/HandlesAttribute.cs
@@ -1,8 +1,14 @@
 ﻿namespace Mocha.AssetCompiler;
 
+/// <summary>
+/// Marks a <see cref="BaseCompiler"/> to handle specified file extensions.
+/// </summary>
 [AttributeUsage( AttributeTargets.Class, AllowMultiple = false, Inherited = false )]
 public class HandlesAttribute : Attribute
 {
+	/// <summary>
+	/// The file extensions the compiler can handle.
+	/// </summary>
 	public string[] Extensions { get; }
 	
 	public HandlesAttribute( params string[] extensions )

--- a/Source/AssetCompiler/Handlers/Material/MaterialCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Material/MaterialCompiler.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 namespace Mocha.AssetCompiler;
 
-[Handles( new[] { ".mmat" } )]
+[Handles( ".mmat" )]
 public class MaterialCompiler : BaseCompiler
 {
 	public override string AssetName => "Material";

--- a/Source/AssetCompiler/Handlers/Material/MaterialCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Material/MaterialCompiler.cs
@@ -19,7 +19,7 @@ public class MaterialCompiler : BaseCompiler
 	public override bool SupportsMochaFile => true;
 
 	/// <inheritdoc/>
-	public override CompileResult CompileFile( ref CompileInput input )
+	public override CompileResult Compile( ref CompileInput input )
 	{
 		var materialData = JsonSerializer.Deserialize<MaterialInfo>( input.SourceData.Span );
 		// Wrapper for file

--- a/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
@@ -2,7 +2,7 @@
 
 namespace Mocha.AssetCompiler;
 
-[Handles( new[] { ".mmdl" } )]
+[Handles( ".mmdl" )]
 public class ModelCompiler : BaseCompiler
 {
 	public override string AssetName => "Model";

--- a/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
@@ -24,7 +24,7 @@ public class ModelCompiler : BaseCompiler
 	private static readonly char[] indexChunk = new char[] { 'I', 'N', 'D', 'X' };
 
 	/// <inheritdoc/>
-	public override CompileResult CompileFile( ref CompileInput input )
+	public override CompileResult Compile( ref CompileInput input )
 	{
 		// TODO: Fix this
 		if ( input.SourcePath is null )

--- a/Source/AssetCompiler/Handlers/Texture/TextureCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Texture/TextureCompiler.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 
 namespace Mocha.AssetCompiler;
 
-[Handles( new[] { ".png", ".jpg" } )]
+[Handles( ".png", ".jpg", ".jpeg" )]
 public partial class TextureCompiler : BaseCompiler
 {
 	public override string AssetName => "Texture";

--- a/Source/AssetCompiler/Handlers/Texture/TextureCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Texture/TextureCompiler.cs
@@ -30,7 +30,7 @@ public partial class TextureCompiler : BaseCompiler
 	};
 
 	/// <inheritdoc/>
-	public override CompileResult CompileFile( ref CompileInput input )
+	public override CompileResult Compile( ref CompileInput input )
 	{
 		var textureMeta = new TextureMetadata();
 		// Check for meta, load if it exists.

--- a/Source/AssetCompiler/Handlers/Texture/TextureCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Texture/TextureCompiler.cs
@@ -2,97 +2,56 @@
 using BCnEncoder.Shared;
 using Mocha.Common.Serialization;
 using StbImageSharp;
-using System.Security.Cryptography;
+using System.Diagnostics;
 using System.Text.Json;
 
 namespace Mocha.AssetCompiler;
 
+/// <summary>
+/// A compiler for .png, .jpg, and .jpeg image files.
+/// </summary>
 [Handles( ".png", ".jpg", ".jpeg" )]
 public partial class TextureCompiler : BaseCompiler
 {
+	/// <inheritdoc/>
 	public override string AssetName => "Texture";
 
-	private static CompressionFormat TextureFormatToCompressionFormat( TextureFormat format )
+	/// <inheritdoc/>
+	public override string CompiledExtension => "mtex_c";
+
+	/// <inheritdoc/>
+	public override bool SupportsMochaFile => true;
+
+	/// <inheritdoc/>
+	public override string[] AssociatedFiles => associatedFiles;
+	private static readonly string[] associatedFiles = new string[]
 	{
-		return format switch
-		{
-			TextureFormat.BC3 => CompressionFormat.Bc3,
-			TextureFormat.BC5 => CompressionFormat.Bc5,
-			TextureFormat.RGBA => CompressionFormat.Rgba,
+		"{SourcePathWithoutExt}.meta"
+	};
 
-			_ => throw new Exception( $"Unsupported texture format {format}" ),
-		};
-	}
-
-	private static byte[] BlockCompression( byte[] data, uint width, uint height, uint mip, TextureFormat format )
+	/// <inheritdoc/>
+	public override CompileResult CompileFile( ref CompileInput input )
 	{
-		BcEncoder encoder = new BcEncoder();
-
-		encoder.OutputOptions.GenerateMipMaps = true;
-		encoder.OutputOptions.Quality = CompressionQuality.BestQuality;
-		encoder.OutputOptions.Format = TextureFormatToCompressionFormat( format );
-		encoder.OutputOptions.FileFormat = OutputFileFormat.Dds;
-
-		return encoder.EncodeToRawBytes( data, (int)width, (int)height, PixelFormat.Rgba32, (int)mip, out _, out _ );
-	}
-
-	private bool IsPowerOfTwo( int x )
-	{
-		return (x & (x - 1)) == 0;
-	}
-
-	private int NextPowerOfTwo( int x )
-	{
-		int i = 0;
-		while ( x > 0 )
-		{
-			x >>= 1;
-			i++;
-		}
-		return 1 << i;
-	}
-
-	public override CompileResult CompileFile( string path )
-	{
-		var destFileName = Path.ChangeExtension( path, "mtex_c" );
-		var metaFileName = Path.ChangeExtension( path, "meta" );
 		var textureMeta = new TextureMetadata();
-		var textureFormat = new TextureInfo();
+		// Check for meta, load if it exists.
+		if ( input.AssociatedData.TryGetValue( "{SourcePathWithoutExt}.meta", out var metaData ) )
+			textureMeta = JsonSerializer.Deserialize<TextureMetadata>( metaData.Span );
 
-		// Load image
-		var fileData = File.ReadAllBytes( path );
-		var image = ImageResult.FromMemory( fileData, ColorComponents.RedGreenBlueAlpha );
-
-		// TODO: Move to a nice generic function somewhere
-		if ( File.Exists( destFileName ) )
+		// Setup image and format.
+		var image = ImageResult.FromMemory( input.SourceData.ToArray(), ColorComponents.RedGreenBlueAlpha );
+		var textureFormat = new TextureInfo
 		{
-			// Read mocha file
-			var existingFile = File.ReadAllBytes( destFileName );
-			var deserializedFile = Serializer.Deserialize<MochaFile<TextureInfo>>( existingFile );
-
-			using var md5 = MD5.Create();
-			var computedHash = md5.ComputeHash( fileData );
-			if ( Enumerable.SequenceEqual( deserializedFile.AssetHash, computedHash ) )
-				return UpToDate( path, destFileName );
-		}
-
-		// Check for meta, load if it exists
-		if ( File.Exists( metaFileName ) )
-		{
-			var metaFile = File.ReadAllText( metaFileName );
-			textureMeta = JsonSerializer.Deserialize<TextureMetadata>( metaFile );
-		}
-
-		textureFormat.DataWidth = (uint)image.Width;
-		textureFormat.DataHeight = (uint)image.Height;
-		textureFormat.Width = (uint)image.Width;
-		textureFormat.Height = (uint)image.Height;
-		textureFormat.MipCount = 5;
+			DataWidth = (uint)image.Width,
+			DataHeight = (uint)image.Height,
+			Width = (uint)image.Width,
+			Height = (uint)image.Height,
+			MipCount = 5,
+			Format = textureMeta.Format
+		};
 		textureFormat.MipData = new byte[textureFormat.MipCount][];
 		textureFormat.MipDataLength = new int[textureFormat.MipCount];
-		textureFormat.Format = textureMeta.Format;
 
-		// If image is not POT, then pad the image with transparent pixels
+		// If image is not POT, then pad the image with transparent pixels.
 		if ( !IsPowerOfTwo( image.Width ) || !IsPowerOfTwo( image.Height ) )
 		{
 			var newWidth = NextPowerOfTwo( image.Width );
@@ -128,37 +87,63 @@ public partial class TextureCompiler : BaseCompiler
 			textureFormat.DataHeight = (uint)newHeight;
 		}
 
+		// Setup mip-maps.
 		for ( uint i = 0; i < textureFormat.MipCount; ++i )
 		{
 			textureFormat.MipData[i] = BlockCompression( image.Data, textureFormat.DataWidth, textureFormat.DataHeight, i, textureMeta.Format );
 			textureFormat.MipDataLength[i] = textureFormat.MipData[i].Length;
 		}
 
-		// Wrapper for file
-		var mochaFile = new MochaFile<TextureInfo>()
+		// Wrapper for file.
+		var mochaFile = new MochaFile<TextureInfo>
 		{
 			MajorVersion = 3,
 			MinorVersion = 1,
-			Data = textureFormat
+			Data = textureFormat,
+			AssetHash = input.DataHash
 		};
 
-		// Calculate original asset hash
-		using ( var md5 = MD5.Create() )
-			mochaFile.AssetHash = md5.ComputeHash( fileData );
+		return Succeeded( Serializer.Serialize( mochaFile ) );
+	}
 
-		// TODO: Runtime compiler will often catch this before we do, this needs fixing
-		try
+	private static CompressionFormat TextureFormatToCompressionFormat( TextureFormat format )
+	{
+		return format switch
 		{
-			// Write result
-			using var fileStream = new FileStream( destFileName, FileMode.Create );
-			using var binaryWriter = new BinaryWriter( fileStream );
-			binaryWriter.Write( Serializer.Serialize( mochaFile ) );
-		}
-		catch ( Exception ex )
+			TextureFormat.BC3 => CompressionFormat.Bc3,
+			TextureFormat.BC5 => CompressionFormat.Bc5,
+			TextureFormat.RGBA => CompressionFormat.Rgba,
+
+			_ => throw new UnreachableException( $"Unsupported texture format {format}" ),
+		};
+	}
+
+	private static byte[] BlockCompression( byte[] data, uint width, uint height, uint mip, TextureFormat format )
+	{
+		var encoder = new BcEncoder();
+
+		encoder.OutputOptions.GenerateMipMaps = true;
+		encoder.OutputOptions.Quality = CompressionQuality.BestQuality;
+		encoder.OutputOptions.Format = TextureFormatToCompressionFormat( format );
+		encoder.OutputOptions.FileFormat = OutputFileFormat.Dds;
+
+		return encoder.EncodeToRawBytes( data, (int)width, (int)height, PixelFormat.Rgba32, (int)mip, out _, out _ );
+	}
+
+	private static bool IsPowerOfTwo( int x )
+	{
+		return (x & (x - 1)) == 0;
+	}
+
+	private static int NextPowerOfTwo( int x )
+	{
+		int i = 0;
+		while ( x > 0 )
 		{
-			return Failed( path, exception: ex );
+			x >>= 1;
+			i++;
 		}
 
-		return Succeeded( path, destFileName );
+		return 1 << i;
 	}
 }

--- a/Source/AssetCompiler/Logger.cs
+++ b/Source/AssetCompiler/Logger.cs
@@ -33,7 +33,9 @@ public class Logger
 	public void Fail( string path, Exception? e = null )
 	{
 		FailCount++;
-		Log( "Fail", $"{path} failed to compile. Error was: {e?.Message ?? "Unknown"}" );
+		Log( "Fail", $"{path} failed to compile. Error was: {e?.Message ?? "Unknown."}" );
+		if ( e.StackTrace is not null )
+			Log( "StackTrace", e.StackTrace );
 	}
 
 	public void Processing( string type, string path )

--- a/Source/Common/ProjectSystem/IAssetCompiler.cs
+++ b/Source/Common/ProjectSystem/IAssetCompiler.cs
@@ -2,8 +2,21 @@
 
 public interface IAssetCompiler
 {
+	/// <summary>
+	/// The currently used asset compiler.
+	/// </summary>
 	static IAssetCompiler? Current { get; set; }
 
+	/// <summary>
+	/// Compiles an asset synchronously.
+	/// </summary>
+	/// <param name="path">The path to the source file.</param>
 	void CompileFile( string path );
+
+	/// <summary>
+	/// Compiles an asset asynchronously.
+	/// </summary>
+	/// <param name="path">The path to the source file.</param>
+	/// <returns>The task that represents the asynchronous operation.</returns>
 	Task CompileFileAsync( string path );
 }

--- a/Source/Common/ProjectSystem/IAssetCompiler.cs
+++ b/Source/Common/ProjectSystem/IAssetCompiler.cs
@@ -5,4 +5,5 @@ public interface IAssetCompiler
 	static IAssetCompiler? Current { get; set; }
 
 	void CompileFile( string path );
+	Task CompileFileAsync( string path );
 }


### PR DESCRIPTION
This PR makes many changes to the asset compiler to improve its usability and performance.

## Up-to-date checking
Checking if an asset needs to be re-compiled is now handled on the `AssetCompilerBase` level. An actual asset compiler only needs to handle compiling its type of asset. This way everything can be handled in a generic manner and prevents multiple IO operations to check file hashes. With this, MD5 hashes are created from all associated files now. For example, the texture asset makes use of an optional ".meta" file so if that ends up getting changed then the asset can be recompiled.

## Asynchronous compilation
The asynchronous compilation is only handled on the `AssetCompilerBase` currently, but it is useful there for asynchronous use of file operations. Async is also the default way of compiling. The synchronous compilation is just done by waiting for the asynchronous version to finish.

## Asset compilation tweaks
Asset compilers no longer work with files on disk*. All information is provided to them through the `CompileInput` struct. This struct will contain the original source path plus all data that may be needed for the compilation process. The resulting data will also contain all of the serialized data that can either be written to disk or used in memory. That choice is left to the user of the compilers.

*Due to the nature of font/model compiling they will still require some files to be read/written.

## Performance
With all of these changes, there are also performance gains to be had. For context on these metrics; I have an Intel I7-8700k @ 3.70GHz which boosts to about 4.50GHz and 32GB of DDR4 @ 2133MHz.

The current version of the asset compiler is able to complete a full compilation in roughly 14.9 seconds. With the new changes, the full compile takes roughly 8.3 seconds.
In regards to compiling over an already compiled set of files. The current version of the asset compiler is able to complete it in roughly 0.64 seconds. With the new changes, the process takes roughly 0.49 seconds. In addition to the improved times the recompiling correctly ignores up-to-date files. The new version will only ever recompile models since they do not support the `MochaFile` asset hashing.
In regards to memory usage, I only tested the full compile but the old version averages about 1.1GB of memory whereas the new version gets about 880MB.