### PR TITLE
Add MochaFile support to mmdl

### DIFF
--- a/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using Mocha.Common.Serialization;
+using System.Text;
 using System.Text.Json;
 
 namespace Mocha.AssetCompiler;
@@ -16,7 +17,7 @@ public class ModelCompiler : BaseCompiler
 	public override string CompiledExtension => "mmdl_c";
 
 	/// <inheritdoc/>
-	public override bool SupportsMochaFile => false;
+	public override bool SupportsMochaFile => true;
 
 	private static readonly char[] magicNumber = new char[] { 'M', 'M', 'S', 'H' };
 	private static readonly char[] materialChunk = new char[] { 'M', 'T', 'R', 'L' };
@@ -104,6 +105,14 @@ public class ModelCompiler : BaseCompiler
 				binaryWriter.Write( index );
 		}
 
-		return Succeeded( stream.ToArray() );
+		var mochaFile = new MochaFile<byte[]>()
+		{
+			MajorVersion = 3,
+			MinorVersion = 0,
+			Data = stream.ToArray(),
+			AssetHash = input.DataHash
+		};
+
+		return Succeeded( Serializer.Serialize( mochaFile ) );
 	}
 }

--- a/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
+++ b/Source/AssetCompiler/Handlers/Model/ModelCompiler.cs
@@ -8,6 +8,7 @@ namespace Mocha.AssetCompiler;
 /// A compiler for .mmdl model files.
 /// </summary>
 [Handles( ".mmdl" )]
+// TODO: All the source files found in the mmdl file should be found by the compiler system.
 public class ModelCompiler : BaseCompiler
 {
 	/// <inheritdoc/>

--- a/Source/Engine/Render/Assets/Model.Loader.cs
+++ b/Source/Engine/Render/Assets/Model.Loader.cs
@@ -1,12 +1,17 @@
-﻿namespace Mocha.Renderer;
+﻿using Mocha.Common.Serialization;
+
+namespace Mocha.Renderer;
 
 partial class Model
 {
 	private void LoadFromPath( string path )
 	{
 		using var _ = new Stopwatch( "Mocha model generation" );
-		using var fileStream = FileSystem.Game.OpenRead( path );
-		using var binaryReader = new BinaryReader( fileStream );
+		var fileBytes = FileSystem.Game.ReadAllBytes( path );
+		var modelFile = Serializer.Deserialize<MochaFile<byte[]>>( fileBytes );
+
+		using var stream = new MemoryStream( modelFile.Data );
+		using var binaryReader = new BinaryReader( stream );
 
 		binaryReader.ReadChars( 4 ); // MMSH
 

--- a/Source/Engine/World/Base/ModelEntity.cs
+++ b/Source/Engine/World/Base/ModelEntity.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using Mocha.Common.Serialization;
+using System.Runtime.InteropServices;
 
 namespace Mocha;
 
@@ -86,8 +87,11 @@ public partial class ModelEntity : BaseEntity
 	public void SetMeshPhysics( string path )
 	{
 		using var _ = new Stopwatch( "Mocha phys model generation" );
-		using var fileStream = FileSystem.Game.OpenRead( path );
-		using var binaryReader = new BinaryReader( fileStream );
+		var fileBytes = FileSystem.Game.ReadAllBytes( path );
+		var modelFile = Serializer.Deserialize<MochaFile<byte[]>>( fileBytes );
+
+		using var stream = new MemoryStream( modelFile.Data );
+		using var binaryReader = new BinaryReader( stream );
 
 		var vertexList = new List<Vector3>();
 


### PR DESCRIPTION
This PR makes compiled mmdls support the MochaFile format. With this, they can now skip compilation when not needed. Currently, the asset hash is only formed from the mmdl file. In the future, it should also take into account the source files it references in the JSON object.