### PR TITLE
Use spdlog for shader compilation errors

### DIFF
--- a/Source/Host/shadercompiler.cpp
+++ b/Source/Host/shadercompiler.cpp
@@ -163,8 +163,8 @@ bool ShaderCompiler::Compile( const ShaderType shader_type, const char* pshader,
 
 	if ( !shader.parse( &builtInResources, 460, false, messages ) )
 	{
-		puts( shader.getInfoLog() );
-		puts( shader.getInfoDebugLog() );
+		spdlog::error( shader.getInfoLog() );
+		spdlog::error( shader.getInfoDebugLog() );
 		return false; // something didn't work
 	}
 
@@ -172,9 +172,8 @@ bool ShaderCompiler::Compile( const ShaderType shader_type, const char* pshader,
 
 	if ( !program.link( messages ) )
 	{
-		puts( shader.getInfoLog() );
-		puts( shader.getInfoDebugLog() );
-		fflush( stdout );
+		spdlog::error( shader.getInfoLog() );
+		spdlog::error( shader.getInfoDebugLog() );
 		return false;
 	}
 


### PR DESCRIPTION
Besides just being generally better, this fixes not being able to see shader compilation errors in Visual Studio. With the change to the Windows subsystem, outputting to stdout wasn't helpful anyways - it's not like you can see stdout when you start the game from command prompt.