### PR TITLE
Fix some editor window resize crashes

### DIFF
--- a/Source/Engine/Editor/DebugOverlay.cs
+++ b/Source/Engine/Editor/DebugOverlay.cs
@@ -33,34 +33,36 @@ public static class DebugOverlay
 		ImGui.SetNextWindowPos( ImGui.GetMainViewport().WorkPos );
 		ImGui.SetNextWindowSize( ImGui.GetMainViewport().WorkSize );
 
-		ImGui.Begin( "debugoverlay", ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoDocking | ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoTitleBar );
-		position += (Vector2)ImGui.GetWindowPos();
+		if ( ImGui.Begin( "debugoverlay", ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoDocking | ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoTitleBar ) )
+		{
+			position += (Vector2)ImGui.GetWindowPos();
 
-		//
-		// Draw shadow first (under main label)
-		//
-		ImGui.SetCursorScreenPos( position + new Vector2( 1, 1 ) );
-		ImGui.PushStyleColor( ImGuiCol.Text, new Vector4( 0, 0, 0, 1 ) );
-		ImGuiX.TextMonospace( obj?.ToString() ?? "null" );
-		ImGui.PopStyleColor();
+			//
+			// Draw shadow first (under main label)
+			//
+			ImGui.SetCursorScreenPos( position + new Vector2( 1, 1 ) );
+			ImGui.PushStyleColor( ImGuiCol.Text, new Vector4( 0, 0, 0, 1 ) );
+			ImGuiX.TextMonospace( obj?.ToString() ?? "null" );
+			ImGui.PopStyleColor();
 
-		//
-		// Draw main label
-		//
-		ImGui.SetCursorScreenPos( position );
-		ImGuiX.TextMonospace( obj?.ToString() ?? "null" );
+			//
+			// Draw main label
+			//
+			ImGui.SetCursorScreenPos( position );
+			ImGuiX.TextMonospace( obj?.ToString() ?? "null" );
 
-		//
-		// Cleanup
-		//
-		ImGui.SetCursorScreenPos( System.Numerics.Vector2.Zero );
+			//
+			// Cleanup
+			//
+			ImGui.SetCursorScreenPos( System.Numerics.Vector2.Zero );
 
-		//
-		// ImGui: Submit an item to validate extent
-		// https://github.com/ocornut/imgui/releases/tag/v1.89#:~:text=Instead%2C%20please-,submit%20an%20item,-%3A%0ABegin(...)
-		//
-		ImGui.Dummy( new Vector2( 0, 0 ) );
-		ImGui.End();
+			//
+			// ImGui: Submit an item to validate extent
+			// https://github.com/ocornut/imgui/releases/tag/v1.89#:~:text=Instead%2C%20please-,submit%20an%20item,-%3A%0ABegin(...)
+			//
+			ImGui.Dummy( new Vector2( 0, 0 ) );
+			ImGui.End();
+		}
 	}
 
 	public static void Render()

--- a/Source/Engine/Editor/Editor.cs
+++ b/Source/Engine/Editor/Editor.cs
@@ -95,8 +95,8 @@ public class Editor
 			ImGui.Text( $"FPS: {Time.FPS}" );
 			ImGui.Text( $"Current time: {Time.Now}" );
 			ImGui.Text( $"Frame time: {(Time.Delta * 1000f).CeilToInt()}ms" );
-		}
 
-		ImGui.End();
+			ImGui.End();
+		}
 	}
 }

--- a/Source/Engine/Editor/ImGuiX.cs
+++ b/Source/Engine/Editor/ImGuiX.cs
@@ -35,9 +35,12 @@ public static class ImGuiX
 			ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.NoScrollbar |
 			ImGuiWindowFlags.NoResize );
 
-		if ( ImGui.GetWindowViewport().ID != ImGui.GetMainViewport().ID )
+		if ( b )
 		{
-			// TODO: This window is its own thing - let's give it an icon
+			if ( ImGui.GetWindowViewport().ID != ImGui.GetMainViewport().ID )
+			{
+				// TODO: This window is its own thing - let's give it an icon
+			}
 		}
 
 		return b;
@@ -85,10 +88,13 @@ public static class ImGuiX
 
 		bool b = ImGui.Begin( name, ImGuiWindowFlags.NoDecoration | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoInputs );
 
-		Vector2 workPos = ImGui.GetMainViewport().WorkPos;
+		if ( b )
+		{
+			Vector2 workPos = ImGui.GetMainViewport().WorkPos;
 
-		ImGui.SetWindowPos( new Vector2( workPos.X + 16, workPos.Y + 16 ) );
-		ImGui.SetWindowSize( new Vector2( -1, -1 ) );
+			ImGui.SetWindowPos( new Vector2( workPos.X + 16, workPos.Y + 16 ) );
+			ImGui.SetWindowSize( new Vector2( -1, -1 ) );
+		}
 
 		return b;
 	}

--- a/Source/Engine/Editor/Windows/BrowserWindow.cs
+++ b/Source/Engine/Editor/Windows/BrowserWindow.cs
@@ -124,9 +124,9 @@ internal class BrowserWindow : EditorWindow
 		if ( ImGuiX.BeginWindow( $"Inspector", ref isVisible ) )
 		{
 			Inspector?.Draw();
-		}
 
-		ImGui.End();
+			ImGui.End();
+		}
 	}
 
 	private void CacheEverything()
@@ -620,8 +620,8 @@ internal class BrowserWindow : EditorWindow
 		{
 			DrawBrowser();
 			DrawInspector();
-		}
 
-		ImGui.End();
+			ImGui.End();
+		}
 	}
 }

--- a/Source/Engine/Editor/Windows/BrowserWindow.cs
+++ b/Source/Engine/Editor/Windows/BrowserWindow.cs
@@ -465,25 +465,27 @@ internal class BrowserWindow : EditorWindow
 				$"{FontAwesome.Cubes} AmbientCG"
 			};
 
-			ImGui.BeginListBox( "##sources", new System.Numerics.Vector2( -1, -1 ) );
+			if ( ImGui.BeginListBox( "##sources", new System.Numerics.Vector2( -1, -1 ) ) )
+			{
+				ImGuiX.TextSubheading( $"{FontAwesome.FaceGrinStars} Special" );
+				foreach ( var source in specialSources )
+					ImGuiX.TextLight( source );
 
-			ImGuiX.TextSubheading( $"{FontAwesome.FaceGrinStars} Special" );
-			foreach ( var source in specialSources )
-				ImGuiX.TextLight( source );
+				ImGuiX.Separator();
 
-			ImGuiX.Separator();
+				ImGuiX.TextSubheading( $"{FontAwesome.Folder} Local" );
+				foreach ( var source in localSources )
+					ImGuiX.TextLight( source );
 
-			ImGuiX.TextSubheading( $"{FontAwesome.Folder} Local" );
-			foreach ( var source in localSources )
-				ImGuiX.TextLight( source );
+				ImGuiX.Separator();
 
-			ImGuiX.Separator();
+				ImGuiX.TextSubheading( $"{FontAwesome.Globe} Online" );
+				foreach ( var source in onlineSources )
+					ImGuiX.TextLight( source );
 
-			ImGuiX.TextSubheading( $"{FontAwesome.Globe} Online" );
-			foreach ( var source in onlineSources )
-				ImGuiX.TextLight( source );
+				ImGui.EndListBox();
+			}
 
-			ImGui.EndListBox();
 			ImGui.EndChild();
 		}
 

--- a/Source/Engine/Editor/Windows/ConsoleWindow.cs
+++ b/Source/Engine/Editor/Windows/ConsoleWindow.cs
@@ -174,8 +174,8 @@ public class ConsoleWindow : EditorWindow
 
 				ImGui.EndTable();
 			}
+			
+			ImGui.End();
 		}
-
-		ImGui.End();
 	}
 }

--- a/Source/Engine/Editor/Windows/Inspectors/BaseInspector.cs
+++ b/Source/Engine/Editor/Windows/Inspectors/BaseInspector.cs
@@ -22,12 +22,13 @@ public class BaseInspector
 		float listBoxHeight = itemCount * lineHeight;
 		listBoxHeight += 8f; // Header spacing
 
-		ImGui.BeginListBox( "##inspector_table", new Vector2( -1, listBoxHeight ) );
+		if ( ImGui.BeginListBox( "##inspector_table", new Vector2( -1, listBoxHeight ) ) )
+		{
+			ImGuiX.TextBold( title );
+			DrawTable( items );
 
-		ImGuiX.TextBold( title );
-		DrawTable( items );
-
-		ImGui.EndListBox();
+			ImGui.EndListBox();
+		}
 	}
 
 	protected void DrawButtons( string filePath )

--- a/Source/Engine/Editor/Windows/Inspectors/MaterialInspector.cs
+++ b/Source/Engine/Editor/Windows/Inspectors/MaterialInspector.cs
@@ -45,26 +45,28 @@ public class MaterialInspector : BaseInspector
 		DrawButtons( material.Path );
 		ImGuiX.Separator();
 
-		ImGui.BeginListBox( "##inspector_table", new( -1, 210 ) );
-		ImGuiX.TextBold( $"{FontAwesome.FaceGrinStars} Material" );
-
-		if ( ImGui.BeginTable( $"##material_slots", 3, ImGuiTableFlags.PadOuterX | ImGuiTableFlags.SizingStretchProp ) )
+		if ( ImGui.BeginListBox( "##inspector_table", new( -1, 210 ) ) )
 		{
-			ImGui.TableSetupColumn( "Preview", ImGuiTableColumnFlags.WidthFixed, 32f );
-			ImGui.TableSetupColumn( "Name", ImGuiTableColumnFlags.WidthFixed, 100f );
-			ImGui.TableSetupColumn( "Value", ImGuiTableColumnFlags.WidthStretch, 1f );
+			ImGuiX.TextBold( $"{FontAwesome.FaceGrinStars} Material" );
 
-			foreach ( var property in material.GetType().GetProperties().Where( x => x.PropertyType == typeof( Texture ) ) )
+			if ( ImGui.BeginTable( $"##material_slots", 3, ImGuiTableFlags.PadOuterX | ImGuiTableFlags.SizingStretchProp ) )
 			{
-				var texture = property.GetValue( material ) as Texture;
+				ImGui.TableSetupColumn( "Preview", ImGuiTableColumnFlags.WidthFixed, 32f );
+				ImGui.TableSetupColumn( "Name", ImGuiTableColumnFlags.WidthFixed, 100f );
+				ImGui.TableSetupColumn( "Value", ImGuiTableColumnFlags.WidthStretch, 1f );
 
-				TextureSlot( ImGuiX.GetDisplayName( property.Name ), texture );
+				foreach ( var property in material.GetType().GetProperties().Where( x => x.PropertyType == typeof( Texture ) ) )
+				{
+					var texture = property.GetValue( material ) as Texture;
+
+					TextureSlot( ImGuiX.GetDisplayName( property.Name ), texture );
+				}
+
+				ImGui.EndTable();
 			}
 
-			ImGui.EndTable();
+			ImGui.EndListBox();
 		}
-
-		ImGui.EndListBox();
 
 		ImGui.SetCursorPosY( windowHeight - windowWidth - 10 );
 		ImGuiX.Image( material.DiffuseTexture, new Vector2( windowWidth, windowWidth ) - new Vector2( 16, 0 ) );

--- a/Source/Engine/Editor/Windows/Inspectors/ObjectInspector.cs
+++ b/Source/Engine/Editor/Windows/Inspectors/ObjectInspector.cs
@@ -78,19 +78,20 @@ public class ObjectInspector : BaseInspector
 		ImGuiX.Separator();
 
 		// Properties.
-		ImGui.BeginChild( "##properties", Vector2.Zero, false, ImGuiWindowFlags.AlwaysVerticalScrollbar | ImGuiWindowFlags.NoBackground );
-
-		foreach ( var (editorCategory, propertyEditors) in propertyEditors )
+		if ( ImGui.BeginChild( "##properties", Vector2.Zero, false, ImGuiWindowFlags.AlwaysVerticalScrollbar | ImGuiWindowFlags.NoBackground ) )
 		{
-			ImGuiX.TextBold( padding + editorCategory );
-			ImGuiX.Separator();
+			foreach ( var (editorCategory, propertyEditors) in propertyEditors )
+			{
+				ImGuiX.TextBold( padding + editorCategory );
+				ImGuiX.Separator();
 
-			foreach ( var propertyEditor in propertyEditors )
-				propertyEditor.Draw();
+				foreach ( var propertyEditor in propertyEditors )
+					propertyEditor.Draw();
 
-			ImGuiX.Separator();
+				ImGuiX.Separator();
+			}
+
+			ImGui.EndChild();
 		}
-
-		ImGui.EndChild();
 	}
 }


### PR DESCRIPTION
This prevents some crashes due to incorrect handling of Begin...() and End...() calls (#21), but it doesn't fix everything, I still can't figure these out:

- Resizing any window to 0 height trips an assert but the error message is no different, it still complains about a BeginChild - EndChild/End mismatch
- Resizing the Browser window to less than 200 width (the size of the sidebar) trips the assert no matter what

The solution for both might just be to set some minimum size constraint. My first thought was to do it like this, but it seems ImGUI doesn't honour this... just like it's not honouring the NoResize window flag in the first place.
```cs
public static bool BeginWindow( string name, ref bool isOpen, Vector2? minimumSize = null, Vector2? maximumSize = null )
{
	ImGui.SetNextWindowSizeConstraints( minimumSize ?? new( 10, 10 ), maximumSize ?? new( -1, -1 ) );

	bool b = ImGui.Begin( name, ref isOpen,
		ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.AlwaysUseWindowPadding |
		ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.NoScrollbar |
		ImGuiWindowFlags.NoResize );

	// ...

	return b;
}
```