### PR TITLE
Fix mouse delta

### DIFF
--- a/Source/Host/window.cpp
+++ b/Source/Host/window.cpp
@@ -174,7 +174,10 @@ bool Window::Update()
 			inputState.mousePosition = { ( float )mme.x, ( float )mme.y };
 
 			if ( m_captureMouse )
-				inputState.mouseDelta = { ( float )mme.xrel, ( float )mme.yrel };
+			{
+				inputState.mouseDelta.x += ( float )mme.xrel;
+				inputState.mouseDelta.y += ( float )mme.yrel;
+			}
 		}
 
 #ifdef _IMGUI


### PR DESCRIPTION
Accumulate mouse delta instead of stomping it

Honestly, I think we should probably also look into how the bigger modern engines do window events and what benefits those methods might have. idTech *seems* to do some sort of decoupling/multithreading for mouse input, though for all I know the thread handles more than just input. Whatever the case may be, there's always a reason for it