### PR TITLE
Move main loop to Root

### DIFF
--- a/Source/Common/Client/Time.cs
+++ b/Source/Common/Client/Time.cs
@@ -8,9 +8,9 @@ public static class Time
 
 	public static List<int> FPSHistory { get; } = new();
 
-	public static void UpdateFrom( float deltaTime )
+	public static void UpdateFrom( float tickDeltaTime )
 	{
-		Delta = deltaTime;
+		Delta = tickDeltaTime;
 		Now = Glue.Engine.GetTime();
 
 		FPS = Glue.Engine.GetFramesPerSecond().CeilToInt();

--- a/Source/Host/baserendercontext.h
+++ b/Source/Host/baserendercontext.h
@@ -288,7 +288,6 @@ enum RenderStatus
 	RENDER_STATUS_INVALID_HANDLE,						// You passed an invalid handle to a render function
 	RENDER_STATUS_SHADER_COMPILE_FAILED,				// The shader failed to compile
 	RENDER_STATUS_WINDOW_SIZE_INVALID,					// The window size is invalid. It might be minimized. This shouldn't be treated as an error.
-	RENDER_STATUS_WINDOW_CLOSE,							// The window was closed. This shouldn't be treated as an error.
 };
 
 // ----------------------------------------------------------------------------------------------------
@@ -508,8 +507,16 @@ public:
 
 	virtual RenderStatus GetWindowSize( Size2D* outSize ) = 0;
 
-	// Update window, fetch inputs etc..
-	virtual RenderStatus UpdateWindow() = 0;
+	/// <summary>
+	/// Update window, fetch inputs etc..
+	/// </summary>
+	virtual void UpdateWindow() = 0;
+
+	/// <summary>
+	/// Did the user try to close the game window?
+	/// </summary>
+	virtual bool GetWindowCloseRequested() = 0;
+
 
 	// ----------------------------------------
 	// ImGui

--- a/Source/Host/baserendercontext.h
+++ b/Source/Host/baserendercontext.h
@@ -344,9 +344,11 @@ protected:
 	// The current vertex buffer
 	VertexBuffer* m_currentVertexBuffer;
 
+
 	// ----------------------------------------
 	// Objects
 	// ----------------------------------------
+
 	virtual RenderStatus CreateImageTexture( ImageTextureInfo_t textureInfo, Handle* outHandle ) = 0;
 	virtual RenderStatus CreateRenderTexture( RenderTextureInfo_t textureInfo, Handle* outHandle ) = 0;
 	virtual RenderStatus SetImageTextureData( Handle handle, TextureData_t pipelineInfo ) = 0;
@@ -380,14 +382,14 @@ public:
 	virtual RenderStatus Startup() = 0;
 	virtual RenderStatus Shutdown() = 0;
 
+
 	// ----------------------------------------
 	// Rendering commands
 	// ----------------------------------------
 
-	// Call this before invoking any render functions.
-
 	/// <summary>
-	/// Begins rendering. This should be matched with a call to EndRendering.
+	/// Begins rendering. Call this before invoking any render functions.
+	/// This should be matched with a call to EndRendering.
 	/// </summary>
 	/// <returns>
 	/// <para>
@@ -401,7 +403,8 @@ public:
 	virtual RenderStatus BeginRendering() = 0;
 
 	/// <summary>
-	/// Ends rendering. This should be matched with a call to BeginRendering.
+	/// Ends rendering.
+	/// This should be matched with a call to BeginRendering.
 	/// </summary>
 	/// <returns>
 	/// <para>
@@ -413,10 +416,11 @@ public:
 	/// </returns>
 	virtual RenderStatus EndRendering() = 0;
 
+
 	// ----------------------------------------
-	//
 	// Low-level rendering
-	//
+	// ----------------------------------------
+
 	/// <summary>
 	/// Binds a pipeline
 	/// </summary>
@@ -466,15 +470,21 @@ public:
 	virtual RenderStatus BindRenderTarget( RenderTexture rt ) = 0;
 
 	/// <summary>
+	/// This will return the size for the current render target.
+	/// </summary>
+	/// <returns><b>RENDER_STATUS_OK</b> if successful, otherwise an error code</returns>
+	virtual RenderStatus GetRenderSize( Size2D* outSize ) = 0;
+
+	/// <summary>
 	/// Get information about the GPU.
 	/// </summary>
 	/// <returns><b>RENDER_STATUS_OK</b> if successful, otherwise an error code</returns>
 	virtual RenderStatus GetGPUInfo( GPUInfo* outInfo ) = 0;
 
+
 	// ----------------------------------------
-	//
 	// High-level rendering
-	//
+	// ----------------------------------------
 
 	/// <summary>
 	/// Begin the ImGUI drawing pass.
@@ -498,13 +508,14 @@ public:
 	virtual RenderStatus GetImGuiTextureID( ImageTexture* texture, void** outTextureId ) = 0;
 
 	// ----------------------------------------
-	//
 	// Windowing
-	//
-	// TODO: Move this elsewhere
-	// This will return the size for the current render target.
-	virtual RenderStatus GetRenderSize( Size2D* outSize ) = 0;
+	// ----------------------------------------
 
+	// TODO: Move these elsewhere
+
+	/// <summary>
+	/// Get the current window size
+	/// </summary>
 	virtual RenderStatus GetWindowSize( Size2D* outSize ) = 0;
 
 	/// <summary>
@@ -520,6 +531,7 @@ public:
 
 	// ----------------------------------------
 	// ImGui
+	// ----------------------------------------
 
 	ImFont* m_mainFont;
 	ImFont* m_monospaceFont;

--- a/Source/Host/engine.h
+++ b/Source/Host/engine.h
@@ -1,11 +1,18 @@
 #pragma once
 #include <defs.h>
 #include <globalvars.h>
+#include <root.h>
 #include <projectmanager.h>
 #include <projectmanifest.h>
 
 namespace Engine
 {
+	GENERATE_BINDINGS inline void Quit()
+	{
+		auto& root = Root::GetInstance();
+		root.Quit();
+	}
+
 	GENERATE_BINDINGS inline int GetCurrentTick()
 	{
 		return g_curTick;

--- a/Source/Host/engine.h
+++ b/Source/Host/engine.h
@@ -18,19 +18,19 @@ namespace Engine
 		return g_curTick;
 	}
 
-	GENERATE_BINDINGS inline float GetDeltaTime()
+	GENERATE_BINDINGS inline float GetFrameDeltaTime()
 	{
-		return g_frameTime;
+		return g_frameDeltaTime;
 	}
 
 	GENERATE_BINDINGS inline float GetTickDeltaTime()
 	{
-		return g_tickTime;
+		return g_tickDeltaTime;
 	}
 
 	GENERATE_BINDINGS inline float GetFramesPerSecond()
 	{
-		return 1.0f / g_frameTime;
+		return 1.0f / g_frameDeltaTime;
 	}
 
 	GENERATE_BINDINGS inline float GetTime()

--- a/Source/Host/globalvars.h
+++ b/Source/Host/globalvars.h
@@ -43,8 +43,8 @@ extern CVarManager* g_cvarManager;
 extern ProjectManager* g_projectManager;
 
 extern float g_curTime;
-extern float g_frameTime;
-extern float g_tickTime;
+extern float g_frameDeltaTime;
+extern float g_tickDeltaTime;
 extern int g_curTick;
 
 extern Vector3 g_cameraPos;

--- a/Source/Host/physicsmanager.cpp
+++ b/Source/Host/physicsmanager.cpp
@@ -98,7 +98,7 @@ void PhysicsManager::Update()
 
 	// Step the world
 	m_physicsInstance->m_physicsSystem.Update(
-	    g_tickTime, collisionSteps, integrationSubSteps, m_physicsInstance->m_tempAllocator, m_physicsInstance->m_jobSystem );
+	    g_tickDeltaTime, collisionSteps, integrationSubSteps, m_physicsInstance->m_tempAllocator, m_physicsInstance->m_jobSystem );
 
 	g_entityDictionary->ForEach( [&]( std::shared_ptr<BaseEntity> entity ) {
 		// Is this a valid entity to do physics stuff on?

--- a/Source/Host/rendermanager.h
+++ b/Source/Host/rendermanager.h
@@ -30,8 +30,8 @@ public:
 	void Startup();
 	void Shutdown();
 
-	void Render();
-	void Run();
+	void DrawOverlaysAndEditor();
+	void DrawGame();
 
 	const char* GetGPUName()
 	{

--- a/Source/Host/root.cpp
+++ b/Source/Host/root.cpp
@@ -48,6 +48,11 @@ namespace EngineProperties
 	BoolCVar Renderdoc( "render.renderdoc", false, CVarFlags::Archive, "Enable renderdoc" );
 } // namespace EngineProperties
 
+FloatCVar timescale( "game.timescale", 1.0f, CVarFlags::Archive, "The speed at which the game world runs." );
+
+// TODO: Server / client
+extern FloatCVar maxFramerate;
+
 void Root::Startup()
 {
 	g_logManager = new LogManager();
@@ -93,7 +98,116 @@ void Root::Shutdown()
 	_CrtDumpMemoryLeaks();
 }
 
+double HiresTimeInSeconds()
+{
+	return std::chrono::duration_cast<std::chrono::duration<double>>(
+	    std::chrono::high_resolution_clock::now().time_since_epoch() )
+	    .count();
+}
+
 void Root::Run()
 {
-	g_renderManager->Run();
+	g_hostManager->FireEvent( "Event.Game.Load" );
+
+	double logicDelta = 1.0 / g_projectManager->GetProject().properties.tickRate;
+
+	double currentTime = HiresTimeInSeconds();
+	double accumulator = 0.0;
+
+	while ( !m_shouldQuit )
+	{
+		double newTime = HiresTimeInSeconds();
+		double frameTime = newTime - currentTime;
+
+		// How quick did we do last frame? Let's limit ourselves if (1.0f / g_frameTime) is more than maxLoopHz
+		float loopHz = 1.0f / frameTime;
+
+		// TODO: Server / client. Perhaps abstract this and set it the tickrate on dedicated servers?
+		float maxLoopHz = maxFramerate.GetValue();
+
+		if ( maxLoopHz > 0 && loopHz > maxLoopHz )
+		{
+			continue;
+		}
+
+		if ( frameTime > 1 / 30.0f )
+			frameTime = 1 / 30.0f;
+
+		currentTime = newTime;
+		accumulator += frameTime;
+
+		//
+		// How long has it been since we last updated the game logic?
+		// We want to update as many times as we can in this frame in
+		// order to match the desired tick rate.
+		//
+		while ( accumulator >= logicDelta )
+		{
+			// Assign previous transforms to all entities
+			g_entityDictionary->ForEach(
+			    [&]( std::shared_ptr<BaseEntity> entity ) { entity->m_transformLastFrame = entity->m_transformCurrentFrame; } );
+
+			g_tickTime = ( float )logicDelta;
+
+			// Update physics
+			g_physicsManager->Update();
+
+			// Update game
+			g_hostManager->Update();
+
+			// TODO: Server / client
+			// 
+// #ifndef DEDICATED_SERVER
+			// Update window
+			g_renderContext->UpdateWindow();
+// #endif
+
+			if ( GetQuitRequested() )
+			{
+				m_shouldQuit = true;
+				break;
+			}
+
+			// Assign current transforms to all entities
+			g_entityDictionary->ForEach(
+			    [&]( std::shared_ptr<BaseEntity> entity ) { entity->m_transformCurrentFrame = entity->m_transform; } );
+
+			g_curTime += logicDelta;
+			accumulator -= logicDelta;
+			g_curTick++;
+		}
+
+		g_frameTime = ( float )frameTime;
+
+// #ifndef DEDICATED_SERVER
+		// Render
+		{
+			const double alpha = accumulator / logicDelta;
+
+			// Assign interpolated transforms to all entities
+			g_entityDictionary->ForEach( [&]( std::shared_ptr<BaseEntity> entity ) {
+				// If this entity was spawned in just now, don't interpolate
+				if ( entity->m_spawnTime == g_curTick )
+					return;
+
+				entity->m_transform =
+				    Transform::Lerp( entity->m_transformLastFrame, entity->m_transformCurrentFrame, ( float )alpha );
+			} );
+
+			g_renderManager->DrawOverlaysAndEditor();
+
+			g_renderManager->DrawGame();
+		}
+// #endif
+	}
+}
+
+bool Root::GetQuitRequested()
+{
+// TODO: Server / client
+// #ifdef DEDICATED_SERVER
+// ...
+// #else
+	return g_renderContext->GetWindowCloseRequested();
+// #endif
 }

--- a/Source/Host/root.h
+++ b/Source/Host/root.h
@@ -3,6 +3,11 @@
 
 class Root : ISubSystem
 {
+private:
+	bool m_shouldQuit = false;
+
+	bool GetQuitRequested();
+
 public:
 	inline static Root& GetInstance()
 	{
@@ -13,4 +18,6 @@ public:
 	void Startup();
 	void Run();
 	void Shutdown();
+
+	void Quit() { m_shouldQuit = true; }
 };

--- a/Source/Host/vulkanrendercontext.cpp
+++ b/Source/Host/vulkanrendercontext.cpp
@@ -1540,16 +1540,6 @@ RenderStatus VulkanRenderContext::GetWindowSize( Size2D* outSize )
 	return RENDER_STATUS_OK;
 }
 
-RenderStatus VulkanRenderContext::UpdateWindow()
-{
-	if ( m_window->Update() )
-	{
-		return RENDER_STATUS_WINDOW_CLOSE;
-	}
-
-	return RENDER_STATUS_OK;
-}
-
 RenderStatus VulkanRenderContext::CreateImageTexture( ImageTextureInfo_t textureInfo, Handle* outHandle )
 {
 	ErrorIf( !m_hasInitialized, RENDER_STATUS_NOT_INITIALIZED );

--- a/Source/Host/vulkanrendercontext.h
+++ b/Source/Host/vulkanrendercontext.h
@@ -531,7 +531,10 @@ public:
 	RenderStatus GetWindowSize( Size2D* outSize ) override;
 
 	/// <inheritdoc />
-	RenderStatus UpdateWindow() override;
+	void UpdateWindow() override { m_window->Update(); }
+
+	/// <inheritdoc />
+	bool GetWindowCloseRequested() override { return m_window->GetCloseRequested(); }
 
 	/// <inheritdoc />
 	RenderStatus GetGPUInfo( GPUInfo* outInfo ) override;

--- a/Source/Host/window.cpp
+++ b/Source/Host/window.cpp
@@ -56,10 +56,9 @@ void Window::Show()
 	m_visible = true;
 }
 
-bool Window::Update()
+void Window::Update()
 {
 	SDL_Event e;
-	bool bQuit = false;
 
 	InputState inputState = g_inputManager->GetState();
 
@@ -72,7 +71,8 @@ bool Window::Update()
 	{
 		if ( e.type == SDL_QUIT )
 		{
-			return true;
+			m_closeRequested = true;
+			return;
 		}
 		else if ( e.type == SDL_WINDOWEVENT )
 		{
@@ -125,8 +125,7 @@ bool Window::Update()
 				// We don't want to quit if an editor window is closed
 				if ( we.windowID == SDL_GetWindowID( m_window ) )
 				{
-					// Main window was closed, so quit
-					bQuit = true;
+					m_closeRequested = true;
 				}
 			}
 		}
@@ -176,6 +175,4 @@ bool Window::Update()
 	}
 
 	g_inputManager->SetState( inputState );
-
-	return bQuit;
 }

--- a/Source/Host/window.h
+++ b/Source/Host/window.h
@@ -10,6 +10,7 @@ class Window
 private:
 	struct SDL_Window* m_window{ nullptr };
 	bool m_visible = false;
+	bool m_closeRequested = false;
 	bool m_captureMouse = true;
 
 public:
@@ -19,8 +20,9 @@ public:
 
 	VkSurfaceKHR CreateSurface( VkInstance instance );
 	bool GetCaptureMouse() { return m_captureMouse; }
+	bool GetCloseRequested() { return m_closeRequested; }
 	void Cleanup();
-	bool Update();
+	void Update();
 	void Show();
 
 	inline SDL_Window* GetSDLWindow() { return m_window; }

--- a/Source/Hotload/Main.cs
+++ b/Source/Hotload/Main.cs
@@ -98,7 +98,7 @@ public static class Main
 		if ( s_game == null )
 			throw new Exception( "Invoke Run() first" );
 
-		Time.UpdateFrom( Glue.Engine.GetDeltaTime() );
+		Time.UpdateFrom( Glue.Engine.GetTickDeltaTime() );
 		Screen.UpdateFrom( Glue.Editor.GetRenderSize() );
 		Input.Update();
 


### PR DESCRIPTION
Changes:

- Moved main loop out of RenderManager into Root
- Changed `Window::Update()` logic to set a `m_closeRequested` flag, should help with future separation of server/client logic
- Changed `g_frameTime` and `g_tickTime` to `g_frameDeltaTime` and `g_tickDeltaTime` for better clarity
- Added `Root::Quit()` and an accompanying binding in `engine.h`. Didn't add anything that uses the binding on the managed side though, not sure where it should go?
- Cleaned things up elsewhere a little in baserendercontext.h for the sake of it, no changes in functionality beyond the window stuff