### PR TITLE
Console System Improvements

### DIFF
--- a/Source/Common/Console/CVarFlags.cs
+++ b/Source/Common/Console/CVarFlags.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mocha.Common;
+
+public enum CVarFlags
+{
+	// Mirrors native
+
+	None = 0,
+
+	// If this isn't present, it's inherently assumed to be a variable
+	Command = 1 << 0,
+
+	// If this is present, it lives in managed space
+	Managed = 1 << 1,
+
+	// This cvar was created by the game, it should be wiped on hotload
+	Game = 1 << 2,
+
+	// Save this convar to cvars.json
+	Archive = 1 << 3,
+
+	Cheat = 1 << 4,
+
+	Temp = 1 << 5,
+
+	Replicated = 1 << 6,
+}

--- a/Source/Common/Console/ConCmd.cs
+++ b/Source/Common/Console/ConCmd.cs
@@ -4,11 +4,11 @@ public static class ConCmd
 {
 	public abstract class BaseAttribute : Attribute
 	{
-		public string Name { get; init; }
-		public CVarFlags Flags { get; init; }
-		public string Description { get; init; }
+		internal string? Name { get; init; }
+		internal CVarFlags Flags { get; init; }
+		internal string? Description { get; init; }
 
-		public BaseAttribute( string name, CVarFlags flags, string description )
+		public BaseAttribute( string? name, CVarFlags flags, string? description )
 		{
 			Name = name;
 			Flags = flags;
@@ -21,14 +21,39 @@ public static class ConCmd
 
 	public sealed class TestAttribute : BaseAttribute
 	{
+		public TestAttribute()
+			: base( null, CVarFlags.None, null )
+		{
+
+		}
 		public TestAttribute( string name )
-			: base( name, CVarFlags.None, "" )
+			: base( name, CVarFlags.None, null )
 		{
 
 		}
 
 		public TestAttribute( string name, string description )
 			: base( name, CVarFlags.None, description )
+		{
+
+		}
+	}
+
+	public sealed class CheatAttribute : BaseAttribute
+	{
+		public CheatAttribute()
+			: base( null, CVarFlags.Cheat, null )
+		{
+
+		}
+		public CheatAttribute( string name )
+			: base( name, CVarFlags.Cheat, null )
+		{
+
+		}
+
+		public CheatAttribute( string name, string description )
+			: base( name, CVarFlags.Cheat, description )
 		{
 
 		}

--- a/Source/Common/Console/ConCmd.cs
+++ b/Source/Common/Console/ConCmd.cs
@@ -1,0 +1,36 @@
+﻿namespace Mocha.Common;
+
+public static class ConCmd
+{
+	public abstract class BaseAttribute : Attribute
+	{
+		public string Name { get; init; }
+		public CVarFlags Flags { get; init; }
+		public string Description { get; init; }
+
+		public BaseAttribute( string name, CVarFlags flags, string description )
+		{
+			Name = name;
+			Flags = flags;
+			Description = description;
+		}
+	}
+
+	// public class ServerAttribute
+	// public class ClientAttribute
+
+	public sealed class TestAttribute : BaseAttribute
+	{
+		public TestAttribute( string name )
+			: base( name, CVarFlags.None, "" )
+		{
+
+		}
+
+		public TestAttribute( string name, string description )
+			: base( name, CVarFlags.None, description )
+		{
+
+		}
+	}
+}

--- a/Source/Common/Console/ConVar.cs
+++ b/Source/Common/Console/ConVar.cs
@@ -1,0 +1,16 @@
+﻿namespace Mocha.Common;
+
+public static class ConVar
+{
+	public abstract class BaseAttribute : Attribute
+	{
+		public required string Name { get; init; }
+		public required CVarFlags Flags { get; init; }
+		public required string Description { get; init; }
+	}
+
+	public class TestAttribute : Attribute
+	{
+
+	}
+}

--- a/Source/Common/Console/ConsoleDispatchInfo.cs
+++ b/Source/Common/Console/ConsoleDispatchInfo.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mocha.Common.Console;
+
+
+[StructLayout( LayoutKind.Sequential )]
+public struct ConCmdDispatchInfo
+{
+	public IntPtr name;
+	public IntPtr data;
+	public int size;
+}
+
+[StructLayout( LayoutKind.Sequential )]
+public struct StringCVarDispatchInfo
+{
+	public IntPtr name;
+	public IntPtr oldValue;
+	public IntPtr newValue;
+}
+
+[StructLayout( LayoutKind.Sequential )]
+public struct FloatCVarDispatchInfo
+{
+	public IntPtr name;
+	public float oldValue;
+	public float newValue;
+}
+
+[StructLayout( LayoutKind.Sequential )]
+public struct BoolCVarDispatchInfo
+{
+	public IntPtr name;
+	public bool oldValue;
+	public bool newValue;
+}

--- a/Source/Common/Console/ConsoleSystem.Internal.cs
+++ b/Source/Common/Console/ConsoleSystem.Internal.cs
@@ -79,7 +79,7 @@ public static partial class ConsoleSystem
 							parameters = parameters
 						};
 
-						RegisterCommand( customAttribute.Name, customAttribute.Flags | extraFlags, customAttribute.Description, callbackInfo );
+						RegisterCommand( customAttribute.Name ?? method.Name, customAttribute.Flags | extraFlags, customAttribute.Description ?? "", callbackInfo );
 					}
 				}
 			}

--- a/Source/Common/Console/ConsoleSystem.Internal.cs
+++ b/Source/Common/Console/ConsoleSystem.Internal.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mocha.Common;
+
+public static partial class ConsoleSystem
+{
+	public static class Internal
+	{
+		internal struct ConCmdCallbackInfo
+		{
+			public required MethodInfo method;
+			public required ParameterInfo[] parameters;
+		}
+
+		internal static class ConVarCallbackStore<T>
+		{
+			public static Dictionary<string, Action<T, T>> Callbacks = new();
+		}
+
+		internal static List<string> s_items = new();
+
+		internal static Dictionary<string, ConCmdCallbackInfo> s_commandCallbacks = new();
+
+		internal static void RegisterCommand( string name, CVarFlags flags, string description, ConCmdCallbackInfo callbackInfo )
+		{
+			Glue.ConsoleSystem.RegisterCommand( name, flags, description );
+			s_commandCallbacks[name] = callbackInfo;
+			s_items.Add( name );
+		}
+
+		internal static void RegisterStringConVar( string name, string value, CVarFlags flags, string description, Action<string, string> callback )
+		{
+			Glue.ConsoleSystem.RegisterString( name, value, flags, description );
+			ConVarCallbackStore<string>.Callbacks[name] = callback;
+			s_items.Add( name );
+		}
+
+		internal static void RegisterFloatConVar( string name, float value, CVarFlags flags, string description, Action<float, float> callback )
+		{
+			Glue.ConsoleSystem.RegisterFloat( name, value, flags, description );
+			ConVarCallbackStore<float>.Callbacks[name] = callback;
+			s_items.Add( name );
+		}
+
+		internal static void RegisterBoolConVar( string name, bool value, CVarFlags flags, string description, Action<bool, bool> callback )
+		{
+			Glue.ConsoleSystem.RegisterBool( name, value, flags, description );
+			ConVarCallbackStore<bool>.Callbacks[name] = callback;
+			s_items.Add( name );
+		}
+
+		/// <summary>
+		/// Register all of the CVars in an assembly
+		/// </summary>
+		/// <param name="assembly">The assembly to grab from</param>
+		/// <param name="extraFlags">Extra flags to force each CVar to have. Used mainly for hotloaded assemblies</param>
+		public static void RegisterAssembly( Assembly assembly, CVarFlags extraFlags = CVarFlags.None )
+		{
+			if ( assembly is null )
+				return;
+
+			foreach ( Type type in assembly.GetTypes() )
+			{
+				foreach ( MethodInfo method in type.GetMethods( BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic ) )
+				{
+					ConCmd.BaseAttribute? customAttribute = method.GetCustomAttribute<ConCmd.BaseAttribute>();
+					if ( customAttribute is not null )
+					{
+						var parameters = method.GetParameters();
+
+						var callbackInfo = new ConCmdCallbackInfo
+						{
+							method = method,
+							parameters = parameters
+						};
+
+						RegisterCommand( customAttribute.Name, customAttribute.Flags | extraFlags, customAttribute.Description, callbackInfo );
+					}
+				}
+			}
+		}
+
+		public static void ClearGameCVars()
+		{
+			foreach ( var name in s_items.ToList() )
+			{
+				bool exists = Glue.ConsoleSystem.Exists( name );
+				CVarFlags flags = Glue.ConsoleSystem.GetFlags( name );
+
+				if ( exists && (flags & CVarFlags.Game) != 0 )
+				{
+					s_items.Remove( name );
+					s_commandCallbacks.Remove( name );
+					ConVarCallbackStore<string>.Callbacks.Remove( name );
+					ConVarCallbackStore<float>.Callbacks.Remove( name );
+					ConVarCallbackStore<bool>.Callbacks.Remove( name );
+
+					Glue.ConsoleSystem.Remove( name );
+				}
+			}
+		}
+
+		public static void DispatchCommand( string name, List<string> dispatchArguments )
+		{
+			if ( !s_commandCallbacks.TryGetValue( name, out ConCmdCallbackInfo callbackInfo ) )
+				return;
+
+			ParameterInfo[] callbackParameters = callbackInfo.parameters;
+
+			if ( callbackParameters.Length == 1 &&
+				callbackParameters[0].ParameterType == dispatchArguments.GetType() )
+			{
+				// All it takes is a List<string> so we can probably assume they want direct access to the arguments
+				callbackInfo.method.Invoke( null, new object[] { dispatchArguments } );
+				return;
+			}
+
+			object?[]? arguments = null;
+
+			if ( callbackParameters.Length > 0 )
+			{
+				//
+				// Softly convert arguments from strings to whatever the callback expects
+				//
+
+				arguments = new object[callbackParameters.Length];
+
+				for ( int i = 0; i < callbackParameters.Length; i++ )
+				{
+					object? value;
+
+					ParameterInfo parameter = callbackParameters[i];
+					Type parameterType = parameter.ParameterType;
+
+					if ( i < dispatchArguments.Count )
+					{
+						// Try to convert
+						if ( !dispatchArguments[i].TryConvert( parameterType, out value ) )
+						{
+							Log.Error( $"Error dispatching ConCmd '{name}': Couldn't convert '{dispatchArguments[i]}' to type {parameterType}" );
+							return;
+						}
+					}
+					else if ( parameter.HasDefaultValue )
+					{
+						// There weren't enough arguments passed in,
+						// but we have a default value, so use that instead
+						value = parameter.DefaultValue;
+					}
+					else
+					{
+						Log.Error( $"Error dispatching ConCmd '{name}': Not enough arguments - expected {callbackParameters.Length}, got {dispatchArguments.Count}" );
+						return;
+					}
+
+					arguments[i] = value;
+				}
+			}
+
+			callbackInfo.method.Invoke( null, arguments );
+		}
+
+		public static void DispatchConVarCallback<T>( string name, T oldValue, T newValue )
+		{
+			if ( !ConVarCallbackStore<T>.Callbacks.TryGetValue( name, out var callback ) )
+				return;
+
+			callback( oldValue, newValue );
+		}
+	}
+}

--- a/Source/Common/Console/ConsoleSystem.cs
+++ b/Source/Common/Console/ConsoleSystem.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Reflection;
+using Mocha.Common.Console;
+
+namespace Mocha.Common;
+
+public static partial class ConsoleSystem
+{
+	public static void Run( string command )
+	{
+		Glue.ConsoleSystem.Run( command );
+	}
+
+	public static float GetFloat( string name )
+	{
+		return Glue.ConsoleSystem.GetFloat( name );
+	}
+
+	public static bool GetBool( string name )
+	{
+		return Glue.ConsoleSystem.GetBool( name );
+	}
+
+	public static void Set( string name, string value )
+	{
+		Glue.ConsoleSystem.SetString( name, value );
+	}
+
+	public static void Set( string name, float value )
+	{
+		Glue.ConsoleSystem.SetFloat( name, value );
+	}
+
+	public static void Set( string name, bool value )
+	{
+		Glue.ConsoleSystem.SetBool( name, value );
+	}
+
+	public static void SetFromString( string name, string value )
+	{
+		Glue.ConsoleSystem.FromString( name, value );
+	}
+}

--- a/Source/Common/Utils/Extensions.cs
+++ b/Source/Common/Utils/Extensions.cs
@@ -76,4 +76,109 @@ public static class StringExtension
 		return result;
 	}
 
+	public static bool TryConvert( this string str, Type t, out object? Value )
+	{
+		Value = null;
+
+		if ( t == typeof( string ) )
+		{
+			Value = str;
+			return true;
+		}
+
+		if ( t == typeof( float ) )
+		{
+			Value = str.ToFloat();
+			return true;
+		}
+
+		if ( t == typeof( double ) )
+		{
+			Value = str.ToDouble();
+			return true;
+		}
+
+		if ( t == typeof( int ) )
+		{
+			Value = str.ToInt();
+			return true;
+		}
+
+		if ( t == typeof( uint ) )
+		{
+			Value = str.ToUInt();
+			return true;
+		}
+
+		if ( t == typeof( long ) )
+		{
+			Value = str.ToLong();
+			return true;
+		}
+
+		if ( t == typeof( ulong ) )
+		{
+			Value = str.ToULong();
+			return true;
+		}
+
+		if ( t == typeof( bool ) )
+		{
+			Value = str.ToBool();
+			return true;
+		}
+
+		return false;
+	}
+
+	public static float ToFloat( this string str, float Default = default )
+	{
+		return float.TryParse( str, out var result ) ? result : Default;
+	}
+
+	public static double ToDouble( this string str, double Default = default )
+	{
+		return double.TryParse( str, out var result ) ? result : Default;
+	}
+
+	public static int ToInt( this string str, int Default = default )
+	{
+		return int.TryParse( str, out var result ) ? result : Default;
+	}
+
+	public static uint ToUInt( this string str, uint Default = default )
+	{
+		return uint.TryParse( str, out var result ) ? result : Default;
+	}
+
+	public static long ToLong( this string str, long Default = default )
+	{
+		return long.TryParse( str, out var result ) ? result : Default;
+	}
+
+	public static ulong ToULong( this string str, ulong Default = default )
+	{
+		return ulong.TryParse( str, out var result ) ? result : Default;
+	}
+
+	public static bool ToBool( this string str )
+	{
+		switch ( str )
+		{
+			case null:
+			case "":
+			case "0":
+				return false;
+
+			default:
+				if ( str.Equals( "yes", StringComparison.OrdinalIgnoreCase ) ||
+					str.Equals( "true", StringComparison.OrdinalIgnoreCase ) ||
+					str.Equals( "on", StringComparison.OrdinalIgnoreCase ) )
+					return true;
+
+				// If it fails to parse as a number, it returns false
+				// If it succeeds and it's not 0, it returns true
+				return float.TryParse( str, out var result ) && result != 0.0f;
+		}
+	}
 }

--- a/Source/Common/Utils/Glue/ConsoleSystem.cs
+++ b/Source/Common/Utils/Glue/ConsoleSystem.cs
@@ -1,9 +1,0 @@
-﻿namespace Mocha.Common;
-
-public static class ConsoleSystem
-{
-	public static void Run( string command )
-	{
-		Glue.ConsoleSystem.Run( command );
-	}
-}

--- a/Source/Host/consolesystem.h
+++ b/Source/Host/consolesystem.h
@@ -8,47 +8,89 @@
 
 namespace ConsoleSystem
 {
-	// Run a console command.
-	// The following formats are currently supported:
-	// - [convar name]: Output the current value for a console variable
-	// - [convar name] [value]: Update a console variable with a new value
 	GENERATE_BINDINGS inline void Run( const char* command )
 	{
-		std::string inputString = std::string( command );
+		CVarSystem::Instance().Run( command );
+	}
 
-		std::stringstream ss( inputString );
+	GENERATE_BINDINGS inline bool Exists( const char* name )
+	{
+		return CVarSystem::Instance().Exists( name );
+	}
 
-		std::string cvarName, cvarValue;
-		ss >> cvarName >> cvarValue;
+	GENERATE_BINDINGS inline void RegisterCommand( const char* name, CVarFlags flags, const char* description )
+	{
+		CVarSystem::Instance().RegisterCommand( name, ( CVarFlags )( CVarFlags::Managed | flags ), description, nullptr );
+	}
 
-		std::stringstream valueStream( cvarValue );
+	GENERATE_BINDINGS inline void RegisterString( const char* name, const char* value, CVarFlags flags, const char* description )
+	{
+		CVarSystem::Instance().RegisterString( name, value, ( CVarFlags )( CVarFlags::Managed | flags ), description, nullptr );
+	}
 
-		if ( cvarName == "list" )
-		{
-// This fails on libclang so we'll ignore it for now...
-#ifndef __clang__
-			// List all available cvars
-			CVarSystem::Instance().ForEach( [&]( CVarEntry& entry ) {
-				spdlog::info( "- '{}': '{}'", entry.m_name, CVarSystem::Instance().ToString( entry.m_name ) );
-				spdlog::info( "\t{}", entry.m_description );
-			} );
-#endif
-		}
-		else if ( !CVarSystem::Instance().Exists( cvarName ) )
-		{
-			spdlog::info( "{} is not a valid command or variable", cvarName );
-		}
-		else
-		{
-			if ( valueStream.str().size() > 0 )
-			{
-				CVarSystem::Instance().FromString( cvarName, cvarValue );
-			}
-			else
-			{
-				cvarValue = CVarSystem::Instance().ToString( cvarName );
-				spdlog::info( "{} is '{}'", cvarName, cvarValue );
-			}
-		}
+	GENERATE_BINDINGS inline void RegisterFloat( const char* name, float value, CVarFlags flags, const char* description )
+	{
+		CVarSystem::Instance().RegisterFloat( name, value, ( CVarFlags )( CVarFlags::Managed | flags ), description, nullptr );
+	}
+
+	GENERATE_BINDINGS inline void RegisterBool( const char* name, bool value, CVarFlags flags, const char* description )
+	{
+		CVarSystem::Instance().RegisterBool( name, value, ( CVarFlags )( CVarFlags::Managed | flags ), description, nullptr );
+	}
+
+	GENERATE_BINDINGS inline void Remove( const char* name )
+	{
+		CVarSystem::Instance().Remove( name );
+	}
+
+	GENERATE_BINDINGS inline CVarFlags GetFlags( const char* name )
+	{
+		return CVarSystem::Instance().GetFlags( name );
+	}
+	
+	// TODO: Not until all memory leak concerns are addressed
+/*
+	GENERATE_BINDINGS inline const char* GetString( const char* name )
+	{
+		return CVarSystem::Instance().GetString( name ).c_str();
+	}
+*/
+
+	GENERATE_BINDINGS inline float GetFloat( const char* name )
+	{
+		return CVarSystem::Instance().GetFloat( name );
+	}
+
+	GENERATE_BINDINGS inline bool GetBool( const char* name )
+	{
+		return CVarSystem::Instance().GetBool( name );
+	}
+
+	GENERATE_BINDINGS inline void SetString( const char* name, const char* value )
+	{
+		CVarSystem::Instance().SetString( name, value );
+	}
+
+	GENERATE_BINDINGS inline void SetFloat( const char* name, float value )
+	{
+		CVarSystem::Instance().SetFloat( name, value );
+	}
+
+	GENERATE_BINDINGS inline void SetBool( const char* name, bool value )
+	{
+		CVarSystem::Instance().SetBool( name, value );
+	}
+
+	// TODO: Not until all memory leak concerns are addressed
+/*
+	GENERATE_BINDINGS inline const char* ToString( const char* name )
+	{
+		
+	}
+*/
+
+	GENERATE_BINDINGS inline void FromString( const char* name, const char* valueStr )
+	{
+		CVarSystem::Instance().FromString( name, valueStr );
 	}
 } // namespace ConsoleSystem

--- a/Source/Host/cvarmanager.cpp
+++ b/Source/Host/cvarmanager.cpp
@@ -5,6 +5,8 @@
 
 size_t CVarSystem::GetHash( std::string string )
 {
+	std::transform( string.begin(), string.end(), string.begin(),
+		[]( unsigned char c ) { return std::tolower( c ); } );
 	return std::hash<std::string>{}( string );
 }
 

--- a/Source/Host/cvarmanager.cpp
+++ b/Source/Host/cvarmanager.cpp
@@ -1,6 +1,7 @@
 #include "cvarmanager.h"
 
 #include <sstream>
+#include <hostmanager.h>
 
 size_t CVarSystem::GetHash( std::string string )
 {
@@ -42,7 +43,7 @@ void CVarSystem::Startup()
 		CVarEntry& entry = m_cvarEntries[hash];
 
 		if ( entry.m_flags & CVarFlags::Archive )
-			FromString( name, value );
+			entry.FromString( value );
 	}
 }
 
@@ -61,35 +62,647 @@ void CVarSystem::Shutdown()
 	cvarFile << std::setw( 4 ) << cvarArchive << std::endl;
 }
 
-void CVarSystem::RegisterString( std::string name, std::string value, CVarFlags flags, std::string description )
+#pragma region Parsing
+
+// I hate parsing text in C/C++. This is super messy.
+// It works though.
+
+std::vector<std::string> CVarSystem::GetStatementArguments( std::string_view statement, size_t cursor, size_t& cursorIndex )
 {
-	Register<std::string>( name, value, flags, description );
+	std::vector<std::string> arguments;
+
+	auto begin = statement.begin();
+	auto end = statement.end();
+
+	bool quoted = false;
+	bool commented = false;
+	std::string_view::const_iterator argumentStart = begin;
+	char lastChar = ' ';
+
+	cursorIndex = -1;
+	bool cursorReached = false;
+
+	auto setCursor = [&]( auto argStart, auto argEnd ) {
+		size_t argStartIndex = argStart - begin;
+		size_t argEndIndex = argEnd - begin;
+		bool set = !cursorReached && ( argStartIndex <= cursor && cursor < argEndIndex );
+		if ( set )
+		{
+			cursorIndex = arguments.size() - 1;
+			cursorReached = true;
+		}
+	};
+
+	for ( auto curChar = begin; curChar != end; curChar++ )
+	{
+		size_t curCharIndex = curChar - begin;
+		auto nextChar = curChar + 1;
+
+		if ( quoted )
+		{
+			if ( *curChar == '"' )
+			{
+				quoted = !quoted;
+				arguments.emplace_back( argumentStart + 1, curChar );
+				setCursor( argumentStart, curChar );
+			}
+			else if ( nextChar == end )
+			{
+				arguments.emplace_back( argumentStart + 1, end );
+				setCursor( argumentStart, end );
+			}
+		}
+		else
+		{
+			switch ( *curChar )
+			{
+			case '"':
+				if ( lastChar != ' ' )
+				{
+					arguments.emplace_back( argumentStart, curChar );
+					setCursor( argumentStart, curChar );
+				}
+
+				quoted = !quoted;
+				argumentStart = curChar;
+				break;
+
+			case ' ':
+				switch ( lastChar )
+				{
+				case ' ':
+				case '"':
+					break;
+				default:
+					arguments.emplace_back( argumentStart, curChar );
+					setCursor( argumentStart, curChar );
+					break;
+				}
+				break;
+
+			case '/':
+				if ( nextChar != end )
+				{
+					if ( *nextChar == '/' )
+					{
+						switch ( lastChar )
+						{
+						case ' ':
+						case '"':
+							break;
+						default:
+							arguments.emplace_back( argumentStart, curChar );
+
+							break;
+						}
+
+						setCursor( argumentStart, curChar );
+
+						// We've entered a comment, nothing left to do, so we bail
+						return arguments;
+					}
+				}
+				break;
+
+			default:
+				switch ( lastChar )
+				{
+				case ' ':
+				case '"':
+					argumentStart = curChar;
+					break;
+				}
+
+				if ( nextChar == end )
+				{
+					arguments.emplace_back( argumentStart, end );
+					setCursor( argumentStart, end );
+				}
+
+				break;
+			}
+		}
+
+		lastChar = *curChar;
+	}
+
+	return arguments;
 }
 
-void CVarSystem::RegisterFloat( std::string name, float value, CVarFlags flags, std::string description )
+static std::tuple<int, bool> GetNextStatementLength( std::string_view line )
 {
-	Register<float>( name, value, flags, description );
+	bool skip = false;
+	bool quoted = false;
+	bool commented = false;
+	int totalLength = line.length();
+	int length = 0;
+
+	auto curChar = line.begin();
+	auto nextChar = curChar + 1;
+
+	for ( ; curChar != line.end(); curChar++, length++ )
+	{
+		nextChar = curChar + 1;
+
+		if ( !commented )
+		{
+			if ( *curChar == '"' )
+			{
+				quoted = !quoted;
+				continue;
+			}
+
+			if ( !quoted )
+			{
+				if ( nextChar != line.end() )
+				{
+					if ( *curChar == '/' && *nextChar == '/' )
+					{
+						commented = true;
+						continue;
+					}
+				}
+
+				if ( *curChar == ';' )
+				{
+					skip = true;
+					break;
+				}
+			}
+
+			if ( *curChar == '\n' )
+			{
+				skip = true;
+				break;
+			}
+		}
+	}
+
+	return { ( curChar != line.end() ? length : totalLength ), skip };
 }
 
-void CVarSystem::RegisterBool( std::string name, bool value, CVarFlags flags, std::string description )
+std::vector<std::string_view> CVarSystem::GetStatements( const std::string& input, size_t cursor, size_t& cursorIndex )
 {
-	Register<bool>( name, value, flags, description );
+	auto begin = input.begin();
+	auto end = input.end();
+	std::vector<std::string_view> statements;
+
+	std::string_view remaining( input );
+	bool cursorReached = false;
+
+	cursorIndex = -1;
+
+	auto setCursor = [&]( size_t statementLength ) {
+		if ( statementLength < cursor )
+		{
+			cursor -= statementLength;
+		}
+		else if ( !cursorReached )
+		{
+			cursorIndex = statements.size() - 1;
+			cursorReached = true;
+		}
+	};
+
+	while ( !remaining.empty() )
+	{
+		auto [length, skip] = GetNextStatementLength( remaining );
+		int skip_length = skip ? length + 1 : length;
+
+		std::string_view statement = remaining.substr( 0, length );
+
+		const char* whitespace = " \t\r";
+
+		size_t prefix = std::min( statement.find_first_not_of( whitespace ), statement.size() );
+		statement.remove_prefix( prefix );
+
+		size_t suffix = std::min( statement.size() - statement.find_last_not_of( whitespace ) - 1, statement.size() );
+		statement.remove_suffix( suffix );
+
+		if ( !statement.empty() )
+			statements.push_back( statement );
+		setCursor( skip_length );
+
+		remaining = remaining.substr( skip_length, remaining.length() );
+	}
+
+	return statements;
+}
+
+std::vector<std::string> CVarSystem::GetStatementArguments( std::string_view statement )
+{
+	size_t cursorIndex;
+	return GetStatementArguments( statement, 0, cursorIndex );
+}
+
+std::vector<std::string_view> CVarSystem::GetStatements( const std::string& input )
+{
+	size_t cursorIndex;
+	return GetStatements( input, 0, cursorIndex );
+}
+
+#pragma endregion
+
+void CVarSystem::Run( const char* input )
+{
+	std::string inputString = std::string( input );
+
+	std::vector<std::string_view> statements = GetStatements( inputString );
+
+	for ( std::string_view& statement : statements )
+	{
+		std::vector<std::string> arguments = GetStatementArguments( statement );
+
+		if ( arguments.size() < 1 )
+			continue;
+
+		std::string& arg0 = arguments.at( 0 );
+
+		if ( !Exists( arg0 ) )
+		{
+			spdlog::info( "{} is not a valid command or variable", arg0 );
+			continue;
+		}
+
+		CVarEntry& entry = GetEntry( arg0 );
+
+		if ( entry.IsCommand() )
+		{
+			auto passedArguments = std::vector<std::string>( arguments.begin() + 1, arguments.end() );
+			entry.InvokeCommand( passedArguments );
+		}
+		else
+		{
+			if ( arguments.size() == 1 )
+			{
+				spdlog::info( "{} is '{}'", arg0, entry.ToString() );
+			}
+			else
+			{
+				// Guaranteed to be at least 2
+				entry.FromString( arguments.at( 1 ) );
+			}
+		}
+	}
+}
+
+bool CVarSystem::Exists( std::string name )
+{
+	return m_cvarEntries.find( GetHash( name ) ) != m_cvarEntries.end();
+}
+
+CVarEntry& CVarSystem::GetEntry( std::string name )
+{
+	assert( Exists( name ) ); // Doesn't exist! Register it first
+
+	size_t hash = GetHash( name );
+	CVarEntry& entry = m_cvarEntries[hash];
+
+	return entry;
+}
+
+void CVarSystem::RegisterCommand( std::string name, CVarFlags flags, std::string description, CCmdCallback callback )
+{
+	// This *has* to have the command flag
+	flags = ( CVarFlags )( flags | CVarFlags::Command );
+
+	CVarEntry entry = {};
+	entry.m_name = name;
+	entry.m_description = ( description != "" ) ? description : "(no description)";
+	entry.m_flags = flags;
+	entry.m_callback = callback;
+
+	assert( entry.IsManaged() || callback != nullptr );
+
+	size_t hash = GetHash( name );
+	m_cvarEntries[hash] = entry;
+}
+
+template <typename T>
+inline void CVarSystem::RegisterVariable( std::string name, T value, CVarFlags flags, std::string description, CVarCallback<T> callback )
+{
+	// This *must not* have the command flag
+	flags = ( CVarFlags )( flags & ~( CVarFlags::Command ) );
+
+	CVarEntry entry = {};
+	entry.m_name = name;
+	entry.m_description = ( description != "" ) ? description : "(no description)";
+	entry.m_flags = flags;
+	entry.m_value = value;
+	entry.m_callback = callback;
+
+	size_t hash = GetHash( name );
+	m_cvarEntries[hash] = entry;
+}
+
+void CVarSystem::RegisterString( std::string name, std::string value, CVarFlags flags, std::string description, CVarCallback<std::string> callback )
+{
+	RegisterVariable<std::string>( name, value, flags, description, callback );
+}
+
+void CVarSystem::RegisterFloat( std::string name, float value, CVarFlags flags, std::string description, CVarCallback<float> callback )
+{
+	RegisterVariable<float>( name, value, flags, description, callback );
+}
+
+void CVarSystem::RegisterBool( std::string name, bool value, CVarFlags flags, std::string description, CVarCallback<bool> callback )
+{
+	RegisterVariable<bool>( name, value, flags, description, callback );
+}
+
+
+void CVarSystem::Remove( std::string name )
+{
+	size_t hash = GetHash( name );
+	m_cvarEntries.erase( hash );
+}
+
+
+void CVarEntry::InvokeCommand( std::vector<std::string> arguments )
+{
+	assert( IsCommand() );
+
+	if ( IsManaged() )
+	{
+		std::vector<const char*> managedArguments;
+
+		for ( auto& argument : arguments )
+			managedArguments.push_back( argument.c_str() );
+
+		CVarManagedCmdDispatchInfo info
+		{
+		    m_name.c_str(),
+			managedArguments.data(),
+			managedArguments.size()
+		};
+
+		g_hostManager->DispatchCommand( info );
+	}
+	else {
+		auto callback = std::any_cast<CCmdCallback>( m_callback );
+
+		if ( callback )
+		{
+			callback( arguments );
+		}
+	}
+}
+
+void CVarSystem::InvokeCommand( std::string name, std::vector<std::string> arguments )
+{
+	if ( !Exists( name ) )
+	{
+		spdlog::error( "Tried to invoke command '{}', but it doesn't exist!", name );
+		return;
+	}
+
+	CVarEntry& entry = GetEntry( name );
+
+	if ( !entry.IsCommand() )
+	{
+		spdlog::error( "Tried to invoke command '{}', but it's a variable!", name );
+		return;
+	}
+	
+	entry.InvokeCommand( arguments );
+}
+
+
+CVarFlags CVarSystem::GetFlags( std::string name )
+{
+	if ( !Exists( name ) )
+	{
+		return CVarFlags::None;
+	}
+
+	return ( CVarFlags )GetEntry( name ).m_flags;
+}
+
+
+// Putting this stuff in the header caused bad juju
+
+template <typename T>
+inline T CVarEntry::GetValue()
+{
+	if ( IsCommand() || m_value.type() != typeid( T ) )
+	{
+		return {};
+	}
+
+	return std::any_cast<T>( m_value );
+}
+
+template <typename T>
+inline void CVarEntry::SetValue( T value )
+{
+	if ( IsCommand() || m_value.type() != typeid( T ) )
+	{
+		return;
+	}
+
+	T oldValue = std::any_cast<T>( m_value );
+	m_value = value;
+
+	if ( IsManaged() )
+	{
+		// This is kinda dirty
+
+		if constexpr ( std::is_same<T, std::string>::value )
+		{
+			CVarManagedVarDispatchInfo<const char*> stringInfo{ m_name.c_str(), oldValue.c_str(), value.c_str() };
+
+			g_hostManager->DispatchStringCVarCallback( stringInfo );
+		}
+		else if constexpr ( std::is_same<T, float>::value )
+		{
+			CVarManagedVarDispatchInfo<T> primitiveInfo{ m_name.c_str(), oldValue, value };
+
+			g_hostManager->DispatchFloatCVarCallback( primitiveInfo );
+		}
+		else if constexpr ( std::is_same<T, bool>::value )
+		{
+			CVarManagedVarDispatchInfo<T> primitiveInfo{ m_name.c_str(), oldValue, value };
+
+			g_hostManager->DispatchBoolCVarCallback( primitiveInfo );
+		}
+	}
+	else
+	{
+		auto callback = std::any_cast<CVarCallback<T>>( m_callback );
+
+		if ( callback )
+		{
+			callback( oldValue, value );
+		}
+	}
+
+	spdlog::info( "{} was set to '{}'.", m_name, value );
+}
+
+
+std::string CVarEntry::GetString()
+{
+	return GetValue<std::string>();
 }
 
 std::string CVarSystem::GetString( std::string name )
 {
-	return Get<std::string>( name );
+	if ( !Exists( name ) )
+	{
+		return "";
+	}
+
+	return GetEntry( name ).GetString();
+}
+
+
+float CVarEntry::GetFloat()
+{
+	return GetValue<float>();
 }
 
 float CVarSystem::GetFloat( std::string name )
 {
-	return Get<float>( name );
+	if ( !Exists( name ) )
+	{
+		return 0.0f;
+	}
+
+	return GetEntry( name ).GetFloat();
+}
+
+
+bool CVarEntry::GetBool()
+{
+	return GetValue<bool>();
 }
 
 bool CVarSystem::GetBool( std::string name )
 {
-	return Get<bool>( name );
+	if ( !Exists( name ) )
+	{
+		return false;
+	}
+
+	return GetEntry( name ).GetBool();
 }
+
+
+void CVarEntry::SetString( std::string value )
+{
+	SetValue<std::string>( value );
+}
+
+void CVarSystem::SetString( std::string name, std::string value )
+{
+	if ( !Exists( name ) )
+	{
+		return;
+	}
+	
+	GetEntry( name ).SetString( value );
+}
+
+
+void CVarEntry::SetFloat( float value )
+{
+	SetValue<float>( value );
+}
+
+void CVarSystem::SetFloat( std::string name, float value )
+{
+	if ( !Exists( name ) )
+	{
+		return;
+	}
+	
+	GetEntry( name ).SetFloat( value );
+}
+
+
+void CVarEntry::SetBool( bool value )
+{
+	SetValue<bool>( value );
+}
+
+void CVarSystem::SetBool( std::string name, bool value )
+{
+	if ( !Exists( name ) )
+	{
+		return;
+	}
+	
+	GetEntry( name ).SetBool( value );
+}
+
+std::string CVarEntry::ToString()
+{
+	const std::type_info& type = m_value.type();
+	std::string valueStr;
+
+	if ( type == typeid( std::string ) )
+		valueStr = std::any_cast<std::string>( m_value );
+	else if ( type == typeid( float ) )
+		valueStr = std::to_string( std::any_cast<float>( m_value ) );
+	else if ( type == typeid( bool ) )
+		valueStr = std::any_cast<bool>( m_value ) ? "true" : "false";
+
+	return valueStr;
+}
+
+std::string CVarSystem::ToString( std::string name )
+{
+	if ( !Exists( name ) )
+	{
+		return "";
+	}
+
+	return GetEntry( name ).ToString();
+}
+
+
+void CVarEntry::FromString( std::string valueStr )
+{
+	std::stringstream valueStream( valueStr );
+
+	auto& type = m_value.type();
+
+	if ( type == typeid( float ) )
+	{
+		float value;
+		valueStream >> value;
+
+		SetValue<float>( value );
+	}
+	else if ( type == typeid( bool ) )
+	{
+		bool value;
+
+		if ( valueStr == "true" || valueStr == "1" || valueStr == "yes" )
+			value = true;
+		else if ( valueStr == "false" || valueStr == "0" || valueStr == "no" )
+			value = false;
+		else
+			assert( false ); // Invalid bool value
+
+		SetValue<bool>( value );
+	}
+	else if ( type == typeid( std::string ) )
+	{
+		SetValue<std::string>( valueStr );
+	}
+}
+
+void CVarSystem::FromString( std::string name, std::string valueStr )
+{
+	if ( !Exists( name ) )
+	{
+		return;
+	}
+	
+	GetEntry( name ).FromString( valueStr );
+}
+
 
 void CVarSystem::ForEach( std::function<void( CVarEntry& entry )> func )
 {
@@ -117,82 +730,6 @@ void CVarSystem::ForEach( std::string filter, std::function<void( CVarEntry& ent
 	}
 }
 
-bool CVarSystem::Exists( std::string name )
-{
-	return m_cvarEntries.find( GetHash( name ) ) != m_cvarEntries.end();
-}
-
-void CVarSystem::FromString( std::string name, std::string valueStr )
-{
-	assert( Exists( name ) ); // Doesn't exist! Register it first
-
-	std::stringstream valueStream( valueStr );
-	size_t hash = GetHash( name );
-	CVarEntry& entry = m_cvarEntries[hash];
-
-	auto& type = entry.m_value.type();
-
-	if ( type == typeid( float ) )
-	{
-		float value;
-		valueStream >> value;
-
-		Set<float>( entry.m_name, value );
-	}
-	else if ( type == typeid( bool ) )
-	{
-		bool value;
-
-		if ( valueStr == "true" || valueStr == "1" || valueStr == "yes" )
-			value = true;
-		else if ( valueStr == "false" || valueStr == "0" || valueStr == "no" )
-			value = false;
-		else
-			assert( false ); // Invalid bool value
-
-		Set<bool>( entry.m_name, value );
-	}
-	else if ( type == typeid( std::string ) )
-	{
-		Set<std::string>( entry.m_name, valueStr );
-	}
-}
-
-std::string CVarSystem::ToString( std::string name )
-{
-	assert( Exists( name ) ); // Doesn't exist! Register it first
-
-	size_t hash = GetHash( name );
-	CVarEntry& entry = m_cvarEntries[hash];
-
-	const std::type_info& type = entry.m_value.type();
-	std::string valueStr;
-
-	if ( type == typeid( std::string ) )
-		valueStr = std::any_cast<std::string>( entry.m_value );
-	else if ( type == typeid( float ) )
-		valueStr = std::to_string( std::any_cast<float>( entry.m_value ) );
-	else if ( type == typeid( bool ) )
-		valueStr = std::any_cast<bool>( entry.m_value ) ? "true" : "false";
-
-	return valueStr;
-}
-
-void CVarSystem::SetString( std::string name, std::string value )
-{
-	Set<std::string>( name, value );
-}
-
-void CVarSystem::SetFloat( std::string name, float value )
-{
-	Set<float>( name, value );
-}
-
-void CVarSystem::SetBool( std::string name, bool value )
-{
-	Set<bool>( name, value );
-}
-
 void CVarManager::Startup()
 {
 	CVarSystem::Instance().Startup();
@@ -202,3 +739,91 @@ void CVarManager::Shutdown()
 {
 	CVarSystem::Instance().Shutdown();
 }
+
+// ----------------------------------------
+// Built-in CVars
+// ----------------------------------------
+
+static std::string GetFlagsString(CVarFlags flags)
+{
+	std::vector<const char*> flagNames;
+
+	if ( flags & CVarFlags::Command )
+		flagNames.push_back( "command" );
+	else
+		flagNames.push_back( "variable" );
+
+	if ( flags & CVarFlags::Managed )
+		flagNames.push_back( "managed" );
+
+	if ( flags & CVarFlags::Game )
+		flagNames.push_back( "game" );
+
+	if ( flags & CVarFlags::Archive )
+		flagNames.push_back( "archive" );
+
+	if ( flags & CVarFlags::Cheat )
+		flagNames.push_back( "cheat" );
+
+	if ( flags & CVarFlags::Temp )
+		flagNames.push_back( "temp" );
+
+	if ( flags & CVarFlags::Replicated )
+		flagNames.push_back( "replicated" );
+
+	std::stringstream ss;
+
+	size_t len = flagNames.size();
+	for ( int i = 0; i < len; i++ )
+	{
+		ss << flagNames[i];
+		if ( i != len - 1 )
+			ss << ", ";
+	}
+
+	return ss.str();
+}
+
+static CCmd ccmd_list( "list", CVarFlags::None, "List all commands and variables",
+	[]( std::vector<std::string> arguments )
+	{
+		auto instance = CVarSystem::Instance();
+
+// This fails on libclang so we'll ignore it for now...
+#ifndef __clang__
+		// List all available cvars
+	    instance.ForEach( [&]( CVarEntry& entry ) {
+		    std::string flagNames = GetFlagsString( (CVarFlags) entry.m_flags );
+
+		    if ( entry.IsCommand() )
+			    spdlog::info( "- '{}' - {}", entry.m_name, flagNames );
+		    else
+			    spdlog::info( "- '{}': '{}' - {}", entry.m_name, entry.ToString(), flagNames );
+			spdlog::info( "\t{}", entry.m_description );
+		} );
+#endif
+	}
+);
+
+// ----------------------------------------
+// Test CVars
+// ----------------------------------------
+
+static FloatCVar cvartest_float( "cvartest.float", 0.0f, CVarFlags::None, "Yeah",
+	[]( float oldValue, float newValue )
+	{
+		spdlog::trace( "cvartest.float changed! old {}, new {}", oldValue, newValue );
+	}
+);
+
+static CCmd cvartest_command( "cvartest.command", CVarFlags::None, "A test command",
+	[]( std::vector<std::string> arguments )
+	{
+		spdlog::trace( "cvartest.command has been invoked! Hooray" );
+		
+		for ( int i = 0; i < arguments.size(); i++ )
+		{
+		    spdlog::trace( "\t{} - '{}'", i, arguments.at( i ) );
+		}
+	}
+);

--- a/Source/Host/hostmanager.cpp
+++ b/Source/Host/hostmanager.cpp
@@ -1,5 +1,7 @@
 #include "hostmanager.h"
 
+#include <cvarmanager.h>
+
 void* HostGlobals::load_library( const char_t* path )
 {
 	HMODULE h = ::LoadLibraryW( path );
@@ -116,6 +118,26 @@ void HostManager::Shutdown() {}
 void HostManager::FireEvent( std::string eventName )
 {
 	Invoke( "FireEvent", ( void* )eventName.c_str() );
+}
+
+void HostManager::DispatchCommand( CVarManagedCmdDispatchInfo info )
+{
+	Invoke( "DispatchCommand", &info );
+}
+
+void HostManager::DispatchStringCVarCallback( CVarManagedVarDispatchInfo<const char*> info )
+{
+	Invoke( "DispatchStringCVarCallback", &info );
+}
+
+void HostManager::DispatchFloatCVarCallback( CVarManagedVarDispatchInfo<float> info )
+{
+	Invoke( "DispatchFloatCVarCallback", &info );
+}
+
+void HostManager::DispatchBoolCVarCallback( CVarManagedVarDispatchInfo<bool> info )
+{
+	Invoke( "DispatchBoolCVarCallback", &info );
 }
 
 inline void HostManager::Invoke( std::string _method, void* params, const char_t* delegateTypeName )

--- a/Source/Host/hostmanager.h
+++ b/Source/Host/hostmanager.h
@@ -16,6 +16,11 @@ using string_t = std::basic_string<char_t>;
 
 typedef int( CORECLR_DELEGATE_CALLTYPE* run_fn )( UnmanagedArgs* args );
 
+struct CVarManagedCmdDispatchInfo;
+
+template <typename T>
+struct CVarManagedVarDispatchInfo;
+
 namespace HostGlobals
 {
 	// Globals to hold hostfxr exports
@@ -52,4 +57,9 @@ public:
 	void Render();
 	void DrawEditor();
 	void FireEvent( std::string eventName );
+
+	void DispatchCommand( CVarManagedCmdDispatchInfo info );
+	void DispatchStringCVarCallback( CVarManagedVarDispatchInfo<const char*> info );
+	void DispatchFloatCVarCallback( CVarManagedVarDispatchInfo<float> info );
+	void DispatchBoolCVarCallback( CVarManagedVarDispatchInfo<bool> info );
 };

--- a/Source/Hotload/Assembly/ProjectAssembly.cs
+++ b/Source/Hotload/Assembly/ProjectAssembly.cs
@@ -96,6 +96,8 @@ internal sealed class ProjectAssembly<TEntryPoint> where TEntryPoint : IGame
 
 			// Unregister events for old interface
 			Event.Unregister( oldGameInterface );
+
+			ConsoleSystem.Internal.ClearGameCVars();
 		}
 
 		// Now that everything's been upgraded, swap the new interface
@@ -103,6 +105,9 @@ internal sealed class ProjectAssembly<TEntryPoint> where TEntryPoint : IGame
 		Swap( newAssembly, newInterface );
 
 		Notify.AddNotification( $"Build successful!", $"Compiled '{_projectAssemblyInfo.AssemblyName}'!", FontAwesome.FaceGrinStars );
+
+		ConsoleSystem.Internal.RegisterAssembly( newAssembly, extraFlags: CVarFlags.Game );
+
 		Event.Run( Event.Game.HotloadAttribute.Name );
 
 		if ( !_buildRequested )

--- a/Source/Hotload/Main.cs
+++ b/Source/Hotload/Main.cs
@@ -149,8 +149,6 @@ public static class Main
 			}
 		}
 
-		Log.Trace( $"Dispatching managed command '{name}'" );
-
 		ConsoleSystem.Internal.DispatchCommand( name, arguments );
 	}
 

--- a/Source/Hotload/Main.cs
+++ b/Source/Hotload/Main.cs
@@ -128,7 +128,7 @@ public static class Main
 	public static void DispatchCommand( IntPtr infoPtr )
 	{
 		var info = Marshal.PtrToStructure<ConCmdDispatchInfo>( infoPtr );
-		var name = Marshal.PtrToStringUTF8( info.name );
+		string? name = Marshal.PtrToStringUTF8( info.name );
 
 		if ( name is null )
 			return;
@@ -156,18 +156,39 @@ public static class Main
 	public static void DispatchStringCVarCallback( IntPtr infoPtr )
 	{
 		var info = Marshal.PtrToStructure<StringCVarDispatchInfo>( infoPtr );
+		string? name = Marshal.PtrToStringUTF8( info.name );
+
+		if ( name is null )
+			return;
+
+		string oldValue = Marshal.PtrToStringUTF8( info.oldValue ) ?? "";
+		string newValue = Marshal.PtrToStringUTF8( info.newValue ) ?? "";
+
+		ConsoleSystem.Internal.DispatchConVarCallback( name, oldValue, newValue );
 	}
 
 	[UnmanagedCallersOnly]
 	public static void DispatchFloatCVarCallback( IntPtr infoPtr )
 	{
 		var info = Marshal.PtrToStructure<FloatCVarDispatchInfo>( infoPtr );
+		string? name = Marshal.PtrToStringUTF8( info.name );
+
+		if ( name is null )
+			return;
+
+		ConsoleSystem.Internal.DispatchConVarCallback( name, info.oldValue, info.newValue );
 	}
 
 	[UnmanagedCallersOnly]
 	public static void DispatchBoolCVarCallback( IntPtr infoPtr )
 	{
 		var info = Marshal.PtrToStructure<BoolCVarDispatchInfo>( infoPtr );
+		string? name = Marshal.PtrToStringUTF8( info.name );
+
+		if ( name is null )
+			return;
+
+		ConsoleSystem.Internal.DispatchConVarCallback( name, info.oldValue, info.newValue );
 	}
 
 	/// <summary>

--- a/Source/Hotload/Main.cs
+++ b/Source/Hotload/Main.cs
@@ -1,5 +1,6 @@
 ﻿global using static Mocha.Common.Global;
 using Mocha.Common;
+using Mocha.Common.Console;
 using MochaTool.AssetCompiler;
 using System.Runtime.InteropServices;
 
@@ -26,6 +27,12 @@ public static class Main
 
 		// Initialize the logger
 		Log = new NativeLogger();
+
+		// TODO: Is there a better way to register these cvars?
+		// Register cvars for assemblies that will never hotload
+		ConsoleSystem.Internal.RegisterAssembly( typeof( Mocha.Hotload.Main ).Assembly );	// Hotload
+		ConsoleSystem.Internal.RegisterAssembly( typeof( Mocha.Common.IGame ).Assembly );	// Common
+		ConsoleSystem.Internal.RegisterAssembly( typeof( Mocha.BaseGame ).Assembly );		// Engine
 
 		// Initialize upgrader, we do this as early as possible to prevent
 		// slowdowns while the engine is running.
@@ -115,6 +122,54 @@ public static class Main
 			return;
 
 		Event.Run( eventName );
+	}
+
+	[UnmanagedCallersOnly]
+	public static void DispatchCommand( IntPtr infoPtr )
+	{
+		var info = Marshal.PtrToStructure<ConCmdDispatchInfo>( infoPtr );
+		var name = Marshal.PtrToStringUTF8( info.name );
+
+		if ( name is null )
+			return;
+
+		var arguments = new List<string>();
+
+		if ( info.size != 0 )
+		{
+			// TODO: Remove this alloc
+			var stringPtrs = new IntPtr[info.size];
+			Marshal.Copy( info.data, stringPtrs, 0, info.size );
+
+			arguments.Capacity = info.size;
+
+			for ( int i = 0; i < info.size; i++ )
+			{
+				arguments.Add( Marshal.PtrToStringUTF8( stringPtrs[i] ) ?? "" );
+			}
+		}
+
+		Log.Trace( $"Dispatching managed command '{name}'" );
+
+		ConsoleSystem.Internal.DispatchCommand( name, arguments );
+	}
+
+	[UnmanagedCallersOnly]
+	public static void DispatchStringCVarCallback( IntPtr infoPtr )
+	{
+		var info = Marshal.PtrToStructure<StringCVarDispatchInfo>( infoPtr );
+	}
+
+	[UnmanagedCallersOnly]
+	public static void DispatchFloatCVarCallback( IntPtr infoPtr )
+	{
+		var info = Marshal.PtrToStructure<FloatCVarDispatchInfo>( infoPtr );
+	}
+
+	[UnmanagedCallersOnly]
+	public static void DispatchBoolCVarCallback( IntPtr infoPtr )
+	{
+		var info = Marshal.PtrToStructure<BoolCVarDispatchInfo>( infoPtr );
 	}
 
 	/// <summary>


### PR DESCRIPTION
Changes:
- Adds bindings to access several console system features from managed
- Adds callbacks to CVars
- Adds commands
    - Created on native side via the `CCmd` class
    - Created on managed side via `ConCmd.X` attributes (only a couple exist right now)
    - Managed dispatch system that converts arguments to the callback's parameter types (see examples)
- Improves functionality of command parsing
    - Sections of the command can be surrounded with quotes `"`, enabling the passing of string arguments containing spaces
    - Commands can be split up into multiple statements to be run one after the other, via semicolons `;` and newlines `\n`
    - Comment out the remainder of a line with `//`
    - If desired, you can pass in a cursor position and the parsing API will give you back which statement and which argument the cursor is in. Useful for autocomplete
    - I hate dealing with strings in C++
 - `list` command has been made a `CCmd` instance, and now lists the flags of each command and variable

<details>
<summary>Usage Examples</summary>

Native CVar with a callback
```cpp
static FloatCVar cvartest_float( "cvartest.float", 0.0f, CVarFlags::None, "Yeah",
	[]( float oldValue, float newValue )
	{
		spdlog::trace( "cvartest.float changed! old {}, new {}", oldValue, newValue );
	}
);
```

Native CCmd
```cpp
static CCmd cvartest_command( "cvartest.command", CVarFlags::None, "A test command",
	[]( std::vector<std::string> arguments )
	{
		spdlog::trace( "cvartest.command has been invoked! Hooray" );
		
		for ( int i = 0; i < arguments.size(); i++ )
		{
		    spdlog::trace( "\t{} - '{}'", i, arguments.at( i ) );
		}
	}
);
```

Several managed ConCmds
```cs
[ConCmd.Test( "cvartest.managed.anything", "This is a description" )]
public static void One( List<string> arguments )
{
	Log.Info( "This is a command, woohoo" );

	foreach ( var arg in arguments )
	{
		Log.Info( $" - {arg}" );
	}
}

[ConCmd.Cheat( "cvartest.managed.string" )]
public static void String( string hello )
{
	Log.Info( hello + " [modified]");
}

[ConCmd.Test( "cvartest.managed.float" )]
public static void Float( float hello )
{
	Log.Info( hello + 20.0f );
}

[ConCmd.Test( "cvartest.managed.double" )]
public static void Double( double hello )
{
	Log.Info( hello + 34.0 );
}

[ConCmd.Test( "cvartest.managed.int" )]
public static void Int( int hello )
{
	Log.Info( hello - 123 );
}

[ConCmd.Test( "cvartest.managed.uint" )]
public static void UInt( uint hello )
{
	Log.Info( hello + 456 );
}

[ConCmd.Test( "cvartest.managed.long" )]
public static void Long( long hello )
{
	Log.Info( hello - 1234 );
}

[ConCmd.Test( "cvartest.managed.ulong" )]
public static void ULong( ulong hello )
{
	Log.Info( hello - 5678 );
}

[ConCmd.Test( "cvartest.managed.bool" )]
public static void Bool( bool hello )
{
	Log.Info( hello );
}

[ConCmd.Test( "cvartest.managed.two" )]
public static void Two( int one, float two )
{
	Log.Info( $"{one}, {two}" );
}

[ConCmd.Test( "cvartest.managed.twodefault" )]
public static void TwoDefault( int one, float two = 10.0f )
{
	Log.Info( $"{one}, {two}" );
}

[ConCmd.Test( "cvartest.managed.threedefault" )]
public static void ThreeDefault( int one, bool two, float three = 10.0f )
{
	Log.Info( $"{one}, {two}, {three}" );
}

[ConCmd.Test( "cvartest.managed.threedefault2" )]
public static void ThreeDefault2( int one, bool two = true, float three = 10.0f )
{
	Log.Info( $"{one}, {two}, {three}" );
}
```

![image](https://user-images.githubusercontent.com/10884425/215709974-5c676cfa-94f9-49ed-b3e1-86c2ca17d908.png)
</details>

Notes:

- While the bindings for registering managed ConVars are there you currently can't make them at the moment, because that really should be done through static properties, but source generation is not my forté. Happy to implement suggestions, unless you want to merge and do it yourself

- A few CVarSystem methods (`GetString()`, `ToString()`) don't have bindings right now due to memory leak concerns
    #43