### PR TITLE
Compiler changes for networking

### DIFF
--- a/Source/Mocha.Common/Attributes/Networking/ClientOnlyAttribute.cs
+++ b/Source/Mocha.Common/Attributes/Networking/ClientOnlyAttribute.cs
@@ -1,6 +1,15 @@
 ﻿namespace Mocha.Common;
 
-[AttributeUsage( AttributeTargets.Method, Inherited = false, AllowMultiple = true )]
+[AttributeUsage( AttributeTargets.Class |
+	AttributeTargets.Interface |
+	AttributeTargets.Struct |
+	AttributeTargets.Enum |
+	AttributeTargets.Field |
+	AttributeTargets.Property |
+	AttributeTargets.Constructor |
+	AttributeTargets.Method |
+	AttributeTargets.Delegate |
+	AttributeTargets.Event, Inherited = true, AllowMultiple = false )]
 public sealed class ClientOnlyAttribute : Attribute
 {
 	public ClientOnlyAttribute()

--- a/Source/Mocha.Common/Attributes/Networking/ServerOnlyAttribute.cs
+++ b/Source/Mocha.Common/Attributes/Networking/ServerOnlyAttribute.cs
@@ -1,6 +1,15 @@
 ﻿namespace Mocha.Common;
 
-[AttributeUsage( AttributeTargets.Method, Inherited = false, AllowMultiple = true )]
+[AttributeUsage( AttributeTargets.Class |
+	AttributeTargets.Interface |
+	AttributeTargets.Struct |
+	AttributeTargets.Enum |
+	AttributeTargets.Field |
+	AttributeTargets.Property |
+	AttributeTargets.Constructor |
+	AttributeTargets.Method |
+	AttributeTargets.Delegate |
+	AttributeTargets.Event, Inherited = true, AllowMultiple = false )]
 public sealed class ServerOnlyAttribute : Attribute
 {
 	public ServerOnlyAttribute()

--- a/Source/Mocha.Hotload/Assembly/ProjectAssembly.cs
+++ b/Source/Mocha.Hotload/Assembly/ProjectAssembly.cs
@@ -1,4 +1,5 @@
 ﻿using Mocha.Common;
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Runtime.Serialization;
@@ -44,6 +45,8 @@ internal sealed class ProjectAssembly<TEntryPoint> where TEntryPoint : IGame
 		 */
 		_buildTask = Build();
 		_buildTask.Wait();
+		Debug.Assert( EntryPoint is not null, $"Initial build of project {assemblyInfo.AssemblyName} failed" );
+
 		CreateFileWatchers();
 	}
 

--- a/Source/Mocha.Hotload/Compilation/Compiler.cs
+++ b/Source/Mocha.Hotload/Compilation/Compiler.cs
@@ -117,7 +117,7 @@ internal static class Compiler
 
 			var encoding = System.Text.Encoding.Default;
 
-			var fileText = File.ReadAllText( filePath );
+			var fileText = await File.ReadAllTextAsync( filePath );
 			var sourceText = SourceText.From( fileText, encoding );
 
 			var syntaxTree = CSharpSyntaxTree.ParseText( sourceText, path: filePath );

--- a/Source/Mocha/Mocha.vcxproj
+++ b/Source/Mocha/Mocha.vcxproj
@@ -74,10 +74,16 @@
     <ExternalIncludePath>$(VULKAN_SDK)\Include;$(SolutionDir)vcpkg_installed\$(Platform)-windows\include;$(SolutionDir)vcpkg_installed\$(Platform)-windows\include\SDL2;$(ExternalIncludePath);$(SolutionDir)Mocha.Host\Thirdparty\imgui;$(SolutionDir)Mocha.Host\</ExternalIncludePath>
     <OutDir>$(SolutionDir)..\build</OutDir>
     <LibraryPath>$(SolutionDir)vcpkg_installed\$(Platform)-windows\lib;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)..\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerDebuggerType>NativeWithManagedCore</LocalDebuggerDebuggerType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ExternalIncludePath>$(SolutionDir)Mocha.Host\Thirdparty\imgui;$(SolutionDir)Mocha.Host\;$(ExternalIncludePath)</ExternalIncludePath>
     <OutDir>$(SolutionDir)..\build</OutDir>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)..\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerDebuggerType>NativeWithManagedCore</LocalDebuggerDebuggerType>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <VcpkgTriplet>x64-windows</VcpkgTriplet>

--- a/Source/MochaDedicatedServer/MochaDedicatedServer.vcxproj
+++ b/Source/MochaDedicatedServer/MochaDedicatedServer.vcxproj
@@ -74,10 +74,16 @@
     <ExternalIncludePath>$(VULKAN_SDK)\Include;$(SolutionDir)vcpkg_installed\$(Platform)-windows\include;$(SolutionDir)vcpkg_installed\$(Platform)-windows\include\SDL2;$(ExternalIncludePath);$(SolutionDir)Mocha.Host\Thirdparty\imgui;$(SolutionDir)Mocha.Host\</ExternalIncludePath>
     <OutDir>$(SolutionDir)..\build</OutDir>
     <LibraryPath>$(SolutionDir)vcpkg_installed\$(Platform)-windows\lib;$(LibraryPath)</LibraryPath>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)..\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerDebuggerType>NativeWithManagedCore</LocalDebuggerDebuggerType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ExternalIncludePath>$(SolutionDir)Mocha.Host\Thirdparty\imgui;$(SolutionDir)Mocha.Host\;$(ExternalIncludePath)</ExternalIncludePath>
     <OutDir>$(SolutionDir)..\build</OutDir>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)..\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerDebuggerType>NativeWithManagedCore</LocalDebuggerDebuggerType>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <VcpkgTriplet>x64-windows</VcpkgTriplet>


### PR DESCRIPTION
This PR does a few things:

- Asserts that the initial compile of projects succeeds. If it fails, it lets you know before Mocha starts freaking out.
- Makes it so you can use `ServerOnly` and `ClientOnly` attributes on any declaration. This way users can strip any code they want down the line.
- Switches any synchronous method usage to async in the compilation process.
- Includes the changes from #49 